### PR TITLE
New sm64 room management and static mesh bounding box implementation for planes.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
     "makefile.extensionOutputFolder": "./.vscode",
-    "cmake.configureOnOpen": true
+    "cmake.configureOnOpen": true,
+    "files.associations": {
+        "types.h": "c",
+        "external_types.h": "c"
+    }
 }

--- a/src/controller.h
+++ b/src/controller.h
@@ -103,6 +103,7 @@ struct IGame {
     virtual Sound::Sample* playSound(int id, const vec3 &pos = vec3(0.0f), int flags = 0) const { return NULL; }
     virtual void playTrack(uint8 track, bool background = false) {}
     virtual void stopTrack()                                     {}
+    virtual void getCurrentAndAdjacentRooms(int *roomsList, int *roomsCount, int currentRoomIndex, int to, int maxDepth, int count=0){}
 };
 
 struct Controller {

--- a/src/controller.h
+++ b/src/controller.h
@@ -71,6 +71,7 @@ struct IGame {
     virtual uint16       getRandomBox(uint16 zone, uint16 *zones) { return 0; }
     virtual uint16       findPath(int ascend, int descend, bool big, int boxStart, int boxEnd, uint16 *zones, uint16 **boxes) { return 0; }
     virtual void         flipMap(bool water = true) {}
+    virtual void         flipMap(int roomsSwitched[][2], int &roomsSwitchedCount, bool water = true) {}
     virtual void setWaterParams(float height) {}
     virtual void waterDrop(const vec3 &pos, float radius, float strength) {}
     virtual void setShader(Core::Pass pass, Shader::Type type, bool underwater = false, bool alphaTest = false) {}

--- a/src/debug.h
+++ b/src/debug.h
@@ -581,7 +581,16 @@ namespace Debug {
             Debug::Draw::triangle(lara->sm64DebugSurfaces->floor.v[0], lara->sm64DebugSurfaces->floor.v[1], lara->sm64DebugSurfaces->floor.v[2], vec4(1.0f, 0.0f, 0.0f, 1.0f), vec4(1.0f, 0.0f, 0.0f, 0.5f));
 
             for(int i=0; i<lara->sm64DebugSurfaces->allGeometryCount; i++){
-                Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
+                switch (lara->sm64DebugSurfaces->allGeometry[i].color)
+                {
+                case 1:
+                    Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(1.0f, 0.9f, 0.0f, 0.5f), vec4(1.0f, 0.9f, 0.0f, 0.3f));
+                    break;
+                
+                default:
+                    Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
+                    break;
+                }                
             }
 
             Core::setDepthTest(true);            

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,10 +1,21 @@
 #ifndef H_DEBUG
 #define H_DEBUG
 
+extern "C" {
+    #include <libsm64/src/libsm64.h>
+	#include <libsm64/src/decomp/include/external_types.h>
+	#include <libsm64/src/decomp/include/surface_terrains.h>
+	#include <libsm64/src/decomp/include/PR/ultratypes.h>
+	#include <libsm64/src/decomp/include/audio_defines.h>
+	#include <libsm64/src/decomp/include/seq_ids.h>
+	#include <libsm64/src/decomp/include/mario_animation_ids.h>
+}
+
 #include "core.h"
 #include "format.h"
 #include "controller.h"
 #include "mesh.h"
+#include "marioMacros.h"
 
 namespace Debug {
 
@@ -569,32 +580,39 @@ namespace Debug {
 
         void sm64debug(Lara *lara, TR::Level *level) {
 
-            if(lara->sm64DebugSurfaces == NULL || !lara->surfaceDebuggerEnabled || !lara->isMario || !level)
+            if(!lara->surfaceDebuggerEnabled || !lara->isMario || !level)
             {
                 return;
             }
+
+            struct SM64DebugSurface floor;
+            struct SM64DebugSurface ceiling;
+            struct SM64DebugSurface wall;
+
+            int facesCount=0;
+
+            struct SM64DebugSurface *faces = sm64_get_collision_surfaces(((Mario*)lara)->marioId, &floor, &ceiling, &wall, &facesCount);
             
             Core::setDepthTest(false);
 
-            Debug::Draw::triangle(lara->sm64DebugSurfaces->wall.v[0], lara->sm64DebugSurfaces->wall.v[1], lara->sm64DebugSurfaces->wall.v[2], vec4(0.0f, 0.0f, 1.0f, 1.0f), vec4(0.0f, 0.0f, 1.0f, 0.5f));
-            Debug::Draw::triangle(lara->sm64DebugSurfaces->ceiling.v[0], lara->sm64DebugSurfaces->ceiling.v[1], lara->sm64DebugSurfaces->ceiling.v[2], vec4(0.0f, 1.0f, 0.0f, 1.0f), vec4(0.0f, 1.0f, 0.0f, 0.5f));
-            Debug::Draw::triangle(lara->sm64DebugSurfaces->floor.v[0], lara->sm64DebugSurfaces->floor.v[1], lara->sm64DebugSurfaces->floor.v[2], vec4(1.0f, 0.0f, 0.0f, 1.0f), vec4(1.0f, 0.0f, 0.0f, 0.5f));
+            Debug::Draw::triangle(CONVERT_DEBUG_FACE_COORDINATES(wall), vec4(0.0f, 0.0f, 1.0f, 1.0f), vec4(0.0f, 0.0f, 1.0f, 0.5f));
+            Debug::Draw::triangle(CONVERT_DEBUG_FACE_COORDINATES(ceiling), vec4(0.0f, 1.0f, 0.0f, 1.0f), vec4(0.0f, 1.0f, 0.0f, 0.5f));
+            Debug::Draw::triangle(CONVERT_DEBUG_FACE_COORDINATES(floor), vec4(1.0f, 0.0f, 0.0f, 1.0f), vec4(1.0f, 0.0f, 0.0f, 0.5f));
 
-            for(int i=0; i<lara->sm64DebugSurfaces->allGeometryCount; i++){
-                switch (lara->sm64DebugSurfaces->allGeometry[i].color)
+            for(int i=0; i<facesCount; i++)
+            {
+                switch(faces[i].color)
                 {
-                case 1:
-                    Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(1.0f, 0.9f, 0.0f, 0.5f), vec4(1.0f, 0.9f, 0.0f, 0.3f));
-                    break;
-                
-                default:
-                    Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
-                    break;
-                }                
-            }
-
-            for(int i=0; i<lara->sm64DebugSurfaces->colliderGeometryCount; i++){
-                Debug::Draw::triangle(lara->sm64DebugSurfaces->colliderGeometry[i].v[0], lara->sm64DebugSurfaces->colliderGeometry[i].v[1], lara->sm64DebugSurfaces->colliderGeometry[i].v[2], vec4(0.9f, 0.0f, 0.9f, 0.5f), vec4(0.9f, 0.0f, 0.9f, 0.3f));       
+                    case EXTERNAL_SURFACE_TYPE_STATIC_SURFACE:
+                        Debug::Draw::triangle(CONVERT_DEBUG_FACE_COORDINATES(faces[i]), vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
+                        break;
+                    case EXTERNAL_SURFACE_TYPE_STATIC_MESH:
+                        Debug::Draw::triangle(CONVERT_DEBUG_FACE_COORDINATES(faces[i]), vec4(1.0f, 0.9f, 0.0f, 0.5f), vec4(1.0f, 0.9f, 0.0f, 0.3f));
+                        break;
+                    case EXTERNAL_SURFACE_TYPE_DYNAMIC_OBJECT:
+                        Debug::Draw::triangle(CONVERT_DEBUG_FACE_COORDINATES(faces[i]), vec4(0.9f, 0.0f, 0.9f, 0.5f), vec4(0.9f, 0.0f, 0.9f, 0.3f));
+                        break;
+                }
             }
 
             for (int i = 0; i < level->roomsCount; i++) {

--- a/src/debug.h
+++ b/src/debug.h
@@ -586,6 +586,10 @@ namespace Debug {
                 case 1:
                     Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(1.0f, 0.9f, 0.0f, 0.5f), vec4(1.0f, 0.9f, 0.0f, 0.3f));
                     break;
+
+                case 2:
+                    Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(0.9f, 0.0f, 0.9f, 0.5f), vec4(0.9f, 0.0f, 0.9f, 0.3f));
+                    break;
                 
                 default:
                     Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));

--- a/src/debug.h
+++ b/src/debug.h
@@ -612,16 +612,6 @@ namespace Debug {
                     Box box;
                     vec3 offset = vec3(float(m.x), float(m.y), float(m.z));
                     sm->getBox(false, m.rotation, box); // visible box
-
-                    Debug::Draw::box(offset + box.min, offset + box.max, vec4(1, 1, 0, 0.25));
-
-                    // if (sm->flags != 2 && ) { // collision box
-                    //     sm->getBox(true, m.rotation, box);
-                    //     Debug::Draw::box(offset + box.min - vec3(10.0f), offset + box.max + vec3(10.0f), vec4(1, 0, 0, 0.50));
-                    // }
-                    
-                    //if (!level.meshOffsets[sm->mesh]) continue;
-                    //const TR::Mesh &mesh = level.meshes[level.meshOffsets[sm->mesh]];
                     
                     {
                         char buf[255];

--- a/src/debug.h
+++ b/src/debug.h
@@ -586,15 +586,15 @@ namespace Debug {
                 case 1:
                     Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(1.0f, 0.9f, 0.0f, 0.5f), vec4(1.0f, 0.9f, 0.0f, 0.3f));
                     break;
-
-                case 2:
-                    Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(0.9f, 0.0f, 0.9f, 0.5f), vec4(0.9f, 0.0f, 0.9f, 0.3f));
-                    break;
                 
                 default:
                     Debug::Draw::triangle(lara->sm64DebugSurfaces->allGeometry[i].v[0], lara->sm64DebugSurfaces->allGeometry[i].v[1], lara->sm64DebugSurfaces->allGeometry[i].v[2], vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
                     break;
                 }                
+            }
+
+            for(int i=0; i<lara->sm64DebugSurfaces->colliderGeometryCount; i++){
+                Debug::Draw::triangle(lara->sm64DebugSurfaces->colliderGeometry[i].v[0], lara->sm64DebugSurfaces->colliderGeometry[i].v[1], lara->sm64DebugSurfaces->colliderGeometry[i].v[2], vec4(0.9f, 0.0f, 0.9f, 0.5f), vec4(0.9f, 0.0f, 0.9f, 0.3f));       
             }
 
             Core::setDepthTest(true);            

--- a/src/debug.h
+++ b/src/debug.h
@@ -567,9 +567,9 @@ namespace Debug {
             }
         }
 
-        void sm64debug(Lara *lara) {
+        void sm64debug(Lara *lara, TR::Level *level) {
 
-            if(lara->sm64DebugSurfaces == NULL || !lara->surfaceDebuggerEnabled || !lara->isMario)
+            if(lara->sm64DebugSurfaces == NULL || !lara->surfaceDebuggerEnabled || !lara->isMario || !level)
             {
                 return;
             }
@@ -595,6 +595,42 @@ namespace Debug {
 
             for(int i=0; i<lara->sm64DebugSurfaces->colliderGeometryCount; i++){
                 Debug::Draw::triangle(lara->sm64DebugSurfaces->colliderGeometry[i].v[0], lara->sm64DebugSurfaces->colliderGeometry[i].v[1], lara->sm64DebugSurfaces->colliderGeometry[i].v[2], vec4(0.9f, 0.0f, 0.9f, 0.5f), vec4(0.9f, 0.0f, 0.9f, 0.3f));       
+            }
+
+            for (int i = 0; i < level->roomsCount; i++) {
+                TR::Room &r = level->rooms[i];
+ 
+                for (int j = 0; j < r.meshesCount; j++) {
+                    TR::Room::Mesh &m  = r.meshes[j];
+                    TR::StaticMesh *sm = &level->staticMeshes[m.meshIndex];
+
+                    if (sm->flags != 2 || !level->meshOffsets[sm->mesh])
+                    {
+                        continue;
+                    }
+
+                    Box box;
+                    vec3 offset = vec3(float(m.x), float(m.y), float(m.z));
+                    sm->getBox(false, m.rotation, box); // visible box
+
+                    Debug::Draw::box(offset + box.min, offset + box.max, vec4(1, 1, 0, 0.25));
+
+                    // if (sm->flags != 2 && ) { // collision box
+                    //     sm->getBox(true, m.rotation, box);
+                    //     Debug::Draw::box(offset + box.min - vec3(10.0f), offset + box.max + vec3(10.0f), vec4(1, 0, 0, 0.50));
+                    // }
+                    
+                    //if (!level.meshOffsets[sm->mesh]) continue;
+                    //const TR::Mesh &mesh = level.meshes[level.meshOffsets[sm->mesh]];
+                    
+                    {
+                        char buf[255];
+                        sprintf(buf, "id: %d", (int)m.meshIndex);
+                        Debug::Draw::text(offset + (box.min + box.max) * 0.5f, vec4(0.5, 0.5, 1.0, 1), buf);
+                    }
+                    
+                    
+                }
             }
 
             Core::setDepthTest(true);            

--- a/src/debug.h
+++ b/src/debug.h
@@ -604,10 +604,10 @@ namespace Debug {
                     TR::Room::Mesh &m  = r.meshes[j];
                     TR::StaticMesh *sm = &level->staticMeshes[m.meshIndex];
 
-                    if (sm->flags != 2 || !level->meshOffsets[sm->mesh])
-                    {
-                        continue;
-                    }
+                    // if (sm->flags != 2 || !level->meshOffsets[sm->mesh])
+                    // {
+                    //     continue;
+                    // }
 
                     Box box;
                     vec3 offset = vec3(float(m.x), float(m.y), float(m.z));
@@ -615,7 +615,7 @@ namespace Debug {
                     
                     {
                         char buf[255];
-                        sprintf(buf, "id: %d", (int)m.meshIndex);
+                        sprintf(buf, "ID: %d", (int)m.meshIndex);
                         Debug::Draw::text(offset + (box.min + box.max) * 0.5f, vec4(0.5, 0.5, 1.0, 1), buf);
                     }
                     

--- a/src/debug.h
+++ b/src/debug.h
@@ -589,9 +589,9 @@ namespace Debug {
             struct SM64DebugSurface ceiling;
             struct SM64DebugSurface wall;
 
-            int facesCount=0;
-
-            struct SM64DebugSurface *faces = sm64_get_collision_surfaces(((Mario*)lara)->marioId, &floor, &ceiling, &wall, &facesCount);
+            int facesCount=sm64_get_collision_surfaces_count(((Mario*)lara)->marioId);
+            struct SM64DebugSurface faces[facesCount];
+            sm64_get_collision_surfaces(((Mario*)lara)->marioId, &floor, &ceiling, &wall, faces);
             
             Core::setDepthTest(false);
 

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -2548,10 +2548,21 @@ struct MarioDoppelganger: Enemy
 	{
 		if (!target)
 		{
-			marioId = sm64_mario_create(pos.x/MARIO_SCALE, -pos.y/MARIO_SCALE, -pos.z/MARIO_SCALE, 0, 0, 0, 0);
+            int nearRooms[256];
+            int nearRoomsCount=0;
+            game->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
+			marioId = sm64_mario_create(pos.x/MARIO_SCALE, -pos.y/MARIO_SCALE, -pos.z/MARIO_SCALE, 0, 0, 0, 0, nearRooms, nearRoomsCount);
 			sm64_set_mario_state(marioId, 0); // remove cap
 			target = (Character*)game->getLara(0);
 		}
+
+        if(marioId!=-1)
+        {
+            int nearRooms[256];
+            int nearRoomsCount=0;
+            game->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
+            sm64_level_update_loaded_rooms_list(marioId, nearRooms, nearRoomsCount);
+        }
 
 		if (stand != STAND_AIR && tickedOnce)
 		{

--- a/src/format.h
+++ b/src/format.h
@@ -2772,7 +2772,7 @@ namespace TR {
             ASSERT(m.minX <= m.maxX && m.minY <= m.maxY && m.minZ <= m.maxZ);
 
             box = ::Box(m.min(), m.max());
-            box.rotate90(k);
+            //box.rotate90(k);
 
             ASSERT(box.min.x <= box.max.x && box.min.y <= box.max.y && box.min.z <= box.max.z);
         }
@@ -6624,6 +6624,22 @@ namespace TR {
         void flipMap() {
             for (int i = 0; i < roomsCount; i++)
                 if (rooms[i].alternateRoom > -1) {
+                    Room &src = rooms[i];
+                    Room &dst = rooms[src.alternateRoom];
+
+                    swap(src, dst);
+                    swap(src.alternateRoom, dst.alternateRoom);
+                }
+            state.flags.flipped = !state.flags.flipped;
+        }
+
+        void flipMap(int rooms_modified[][2], int &modified_count) {
+            modified_count = 0;
+            for (int i = 0; i < roomsCount; i++)
+                if (rooms[i].alternateRoom > -1) {
+                    rooms_modified[modified_count][0]=i;
+                    rooms_modified[modified_count++][1]=rooms[i].alternateRoom;
+                    rooms[i].alternateRoom;
                     Room &src = rooms[i];
                     Room &dst = rooms[src.alternateRoom];
 

--- a/src/format.h
+++ b/src/format.h
@@ -2772,7 +2772,18 @@ namespace TR {
             ASSERT(m.minX <= m.maxX && m.minY <= m.maxY && m.minZ <= m.maxZ);
 
             box = ::Box(m.min(), m.max());
-            //box.rotate90(k);
+            box.rotate90(k);
+
+            ASSERT(box.min.x <= box.max.x && box.min.y <= box.max.y && box.min.z <= box.max.z);
+        }
+
+        void getBox(bool collision, ::Box &box) {
+
+            MinMax &m = collision ? cbox : vbox;
+
+            ASSERT(m.minX <= m.maxX && m.minY <= m.maxY && m.minZ <= m.maxZ);
+
+            box = ::Box(m.min(), m.max());
 
             ASSERT(box.min.x <= box.max.x && box.min.y <= box.max.y && box.min.z <= box.max.z);
         }

--- a/src/lara.h
+++ b/src/lara.h
@@ -2271,8 +2271,11 @@ struct Lara : Character {
         }
 
         if (needFlip) {
-            game->flipMap();
+            int roomsSwitched[level->roomsCount][2];
+			int roomsSwitchedCount=0;
+            game->flipMap(roomsSwitched, roomsSwitchedCount);
             game->setEffect(this, effect);
+            sm64_level_rooms_switch(roomsSwitched, roomsSwitchedCount);
         }
     }
 

--- a/src/lara.h
+++ b/src/lara.h
@@ -329,29 +329,6 @@ struct Lara : Character {
 
     int32       networkInput;
 
-    struct sm64DebugSurface{
-        bool isValid=false;
-        vec3 v[3];
-    };
-
-    struct sm64DebugGenericSurface{
-        vec3 v[3];
-        uintptr_t surfacePointer;
-        int color;
-    };
-
-    struct sm64DebugSurfacesSt{
-        struct sm64DebugGenericSurface floor;
-        struct sm64DebugGenericSurface wall;
-        struct sm64DebugGenericSurface ceiling;
-        struct sm64DebugGenericSurface *allGeometry;
-        int allGeometryCount;
-        struct sm64DebugGenericSurface *colliderGeometry;
-        int colliderGeometryCount;
-    };
-
-    struct sm64DebugSurfacesSt *sm64DebugSurfaces = NULL;
-
     bool surfaceDebuggerEnabled = false;
 
 #ifdef _DEBUG

--- a/src/lara.h
+++ b/src/lara.h
@@ -346,6 +346,8 @@ struct Lara : Character {
         struct sm64DebugGenericSurface ceiling;
         struct sm64DebugGenericSurface *allGeometry;
         int allGeometryCount;
+        struct sm64DebugGenericSurface *colliderGeometry;
+        int colliderGeometryCount;
     };
 
     struct sm64DebugSurfacesSt *sm64DebugSurfaces = NULL;

--- a/src/lara.h
+++ b/src/lara.h
@@ -337,6 +337,7 @@ struct Lara : Character {
     struct sm64DebugGenericSurface{
         vec3 v[3];
         uintptr_t surfacePointer;
+        int color;
     };
 
     struct sm64DebugSurfacesSt{

--- a/src/level.h
+++ b/src/level.h
@@ -3129,7 +3129,7 @@ struct Level : IGame {
         //    Debug::Level::path(level, (Enemy*)level.entities[21].controller);
         //    Debug::Level::debugOverlaps(level, players[0]->box);
         //    Debug::Level::debugBoxes(level, lara->dbgBoxes, lara->dbgBoxesCount);
-            Debug::Level::sm64debug(players[0]);
+            Debug::Level::sm64debug(players[0], &level);
             Core::setDepthTest(true);
             Core::setBlendMode(bmNone);
         /*// render ambient cube

--- a/src/level.h
+++ b/src/level.h
@@ -272,7 +272,10 @@ struct Level : IGame {
             }
 
             if (level.state.flags.flipped) {
-                flipMap();
+                int roomsSwitched[level.roomsCount][2];
+                int roomsSwitchedCount=0;
+                flipMap(roomsSwitched, roomsSwitchedCount);
+                sm64_level_rooms_switch(roomsSwitched, roomsSwitchedCount);
                 level.state.flags.flipped = true;
             }
 

--- a/src/level.h
+++ b/src/level.h
@@ -261,7 +261,7 @@ struct Level : IGame {
                     {
                         sm64_set_mario_position( ((Mario*)lara)->marioId, lara->pos.x/MARIO_SCALE, -lara->pos.y/MARIO_SCALE, -lara->pos.z/MARIO_SCALE);
                         sm64_set_mario_faceangle( ((Mario*)lara)->marioId, (int16_t)((-lara->angle.y + M_PI) / M_PI * 32768.0f));
-                        ((Mario*)lara)->marioUpdateRoom(TR::NO_ROOM);
+                        ((Mario*)lara)->updateMarioVisibleRooms();
                         ((Mario*)lara)->currPos[0] = ((Mario*)lara)->lastPos[0] = lara->pos.x;
                         ((Mario*)lara)->currPos[1] = ((Mario*)lara)->lastPos[1] = -lara->pos.y;
                         ((Mario*)lara)->currPos[2] = ((Mario*)lara)->lastPos[2] = -lara->pos.z;
@@ -510,7 +510,16 @@ struct Level : IGame {
         updateBlocks(false);
         if (water && waterCache) waterCache->flipMap();
         mesh->flipMap();
-        level.flipMap();
+        level.flipMap();        
+        updateBlocks(true);
+    }
+
+    virtual void flipMap(int roomsSwitched[][2], int &roomsSwitchedCount, bool water = true) 
+    {
+        updateBlocks(false);
+        if (water && waterCache) waterCache->flipMap();
+        mesh->flipMap();
+        level.flipMap(roomsSwitched, roomsSwitchedCount);        
         updateBlocks(true);
     }
 
@@ -1103,7 +1112,7 @@ struct Level : IGame {
 
         Core::resetTime();
 
-        if (player && player->isMario) ((Mario*)player)->marioUpdateRoom(TR::NO_ROOM);
+        if (player && player->isMario) ((Mario*)player)->updateMarioVisibleRooms();
     }
 
     virtual ~Level() {

--- a/src/level.h
+++ b/src/level.h
@@ -473,6 +473,48 @@ struct Level : IGame {
         return (players[0]->pos - pos).length2() < (players[1]->pos - pos).length2() ? players[0] : players[1];
     }
 
+    virtual void getCurrentAndAdjacentRooms(int *roomsList, int *roomsCount, int currentRoomIndex, int to, int maxDepth, int count=0) {
+        if (count>maxDepth) {
+            return;
+        }
+
+		// if we are starting to search we set all levels visibility to false
+		if(count==0)
+		{
+			for (int i = 0; i < getLevel()->roomsCount; i++)
+				getLevel()->rooms[i].flags.visible = false;
+		}
+
+		//Hardcoded exceptions to avoid invisible collisions
+		switch (getLevel()->id)
+		{
+		case TR::LVL_TR1_10B: //Atlantis
+			switch (currentRoomIndex)
+			{
+			case 47: //room with blocks and switches to trapdoors
+				if(to==84)
+					return;
+			}
+		}
+
+		count++;
+
+        TR::Room &room = getLevel()->rooms[to];
+
+		if(!room.flags.visible){
+			room.flags.visible = true;
+			roomsList[*roomsCount] = to;
+			*roomsCount+=1;
+		}
+
+		if(*roomsCount == 256)
+			return;
+
+		for (int i = 0; i < room.portalsCount; i++) {
+			getCurrentAndAdjacentRooms(roomsList, roomsCount, currentRoomIndex, room.portals[i].roomIndex, maxDepth, count);
+		}
+    }
+
     virtual bool isCutscene() {
         if (level.isTitle()) return false;
         return camera->mode == Camera::MODE_CUTSCENE;

--- a/src/level.h
+++ b/src/level.h
@@ -2462,15 +2462,19 @@ struct Level : IGame {
             Input::down[ikF2] = false;
         }
         if (Input::down[ikF3]) {
-            Lara *lara = (Lara *)getLara();
-            if(lara!=NULL)
+            for(int i =0; i<2; i++)
             {
-                lara->surfaceDebuggerEnabled=!lara->surfaceDebuggerEnabled;
-
-                if(lara->surfaceDebuggerEnabled && lara->isMario)
+                Lara *lara = (Lara *)getLara(i);
+                if(lara!=NULL && lara->isMario)
                 {
-                    lara->debug_get_sm64_collisions();
-                    lara->debug_get_sm64_all_surfaces();
+                    lara->surfaceDebuggerEnabled=!lara->surfaceDebuggerEnabled;
+
+                    if(lara->surfaceDebuggerEnabled && lara->isMario)
+                    {
+                        lara->debug_get_sm64_collisions();
+                        lara->debug_get_sm64_all_surfaces();
+                    }
+                    break;
                 }
             }
             Input::down[ikF3] = false;
@@ -3183,7 +3187,15 @@ struct Level : IGame {
         //    Debug::Level::path(level, (Enemy*)level.entities[21].controller);
         //    Debug::Level::debugOverlaps(level, players[0]->box);
         //    Debug::Level::debugBoxes(level, lara->dbgBoxes, lara->dbgBoxesCount);
-            Debug::Level::sm64debug(players[0], &level);
+            for(int i=0; i<2; i++)
+            {
+                Lara *lara = (Lara *)getLara(i);
+                if(lara->isMario){
+                    Debug::Level::sm64debug(players[i], &level);
+                    break;
+                }
+            }
+            
             Core::setDepthTest(true);
             Core::setBlendMode(bmNone);
         /*// render ambient cube

--- a/src/mario.h
+++ b/src/mario.h
@@ -1584,6 +1584,7 @@ struct Mario : Lara
 					boundingBox = generateMeshBoundingBox(sm);					
 					break;
 				}
+				break;
 			case TR::LevelID::LVL_TR1_1: //Caves
 				switch (m.meshIndex)
 				{
@@ -1591,6 +1592,7 @@ struct Mario : Lara
 				// 	boundingBox = generateMeshBoundingBox(sm);					
 				// 	break;
 				}
+				break;
 			case TR::LevelID::LVL_TR1_3A: //The Lost Valley
 				switch (m.meshIndex)
 				{
@@ -1609,6 +1611,7 @@ struct Mario : Lara
 					boundingBox = generateMeshBoundingBox(sm);
 					break;
 				}
+				break;
 			case TR::LevelID::LVL_TR1_8B: //Obelisk of Khamoon
 				switch (m.meshIndex)
 				{
@@ -1616,6 +1619,7 @@ struct Mario : Lara
 				// 	boundingBox = generateMeshBoundingBox(sm);
 				// 	break;
 				}
+				break;
 			}
 			
 			if(boundingBox)

--- a/src/mario.h
+++ b/src/mario.h
@@ -1934,6 +1934,8 @@ struct Mario : Lara
 		sm64DebugSurfaces->floor.surfacePointer=0;
 		sm64DebugSurfaces->allGeometry = NULL;
 		sm64DebugSurfaces->allGeometryCount=0;
+		sm64DebugSurfaces->colliderGeometry=NULL;
+		sm64DebugSurfaces->allGeometryCount=0;
 
 		reset_vertex_array_coordinates(sm64DebugSurfaces->wall.v);
 		reset_vertex_array_coordinates(sm64DebugSurfaces->ceiling.v);
@@ -1973,10 +1975,20 @@ struct Mario : Lara
 		struct SM64DebugSurface ceiling;
 		ceiling.surfacePointer = sm64DebugSurfaces->ceiling.surfacePointer;
 
-		sm64_get_collision_surfaces(&floor, &ceiling, &wall);
+		struct SM64DebugSurface *imported = sm64_get_collision_surfaces(&floor, &ceiling, &wall, &(sm64DebugSurfaces->colliderGeometryCount));
 		importSM64debugSurface(&(sm64DebugSurfaces->wall), wall);
 		importSM64debugSurface(&(sm64DebugSurfaces->floor), floor);
 		importSM64debugSurface(&(sm64DebugSurfaces->ceiling), ceiling);
+
+		if(sm64DebugSurfaces->colliderGeometry!=NULL) {
+			free(sm64DebugSurfaces->colliderGeometry);
+		}
+
+		sm64DebugSurfaces->colliderGeometry = (struct sm64DebugGenericSurface*) malloc(sizeof(struct sm64DebugGenericSurface)*sm64DebugSurfaces->colliderGeometryCount);
+
+		for(int i=0; i<sm64DebugSurfaces->colliderGeometryCount; i++){
+			importSM64debugSurface(&(sm64DebugSurfaces->colliderGeometry[i]), imported[i]);
+		}
 	}
 
 	virtual void debug_get_sm64_all_surfaces()

--- a/src/mario.h
+++ b/src/mario.h
@@ -1591,6 +1591,24 @@ struct Mario : Lara
 				// 	boundingBox = generateMeshBoundingBox(sm);					
 				// 	break;
 				}
+			case TR::LevelID::LVL_TR1_3A: //The Lost Valley
+				switch (m.meshIndex)
+				{
+				case 0:	// branches
+				case 1:	// branches
+				case 2: // tree/bushes
+				case 3: // tree/bushes
+				case 4: // tree/bushes
+				case 5: // tree/bushes
+				case 6: // dead tree trunk get mario stuck. we will ignore it.
+				case 7: // trees
+				case 8: // trees
+					continue;
+				case 12: // skeleton
+				case 13: // skeleton
+					boundingBox = generateMeshBoundingBox(sm);
+					break;
+				}
 			case TR::LevelID::LVL_TR1_8B: //Obelisk of Khamoon
 				switch (m.meshIndex)
 				{

--- a/src/mario.h
+++ b/src/mario.h
@@ -120,10 +120,10 @@ struct Mario : Lara
 		TRmarioMesh = new Mesh((Index*)marioRenderState.mario.index, marioRenderState.mario.num_vertices, NULL, 0, 1, true, true);
 		TRmarioMesh->initMario(&marioGeometry);
 
-		//roomsFlipControl = (TR::Room **)malloc((sizeof(struct TR::Room*))*level->roomsCount);
-
+		
 		if (!game->getLara(0) || !game->getLara(0)->isMario) 
 		{
+			printf("Loading level %d", level->id);
 			sm64_level_init(level->roomsCount);
 			for(int i=0; i< level->roomsCount; i++)
 			{
@@ -1436,6 +1436,113 @@ struct Mario : Lara
 		return collision_surfaces;
 	}
 
+	TR::Mesh *generateMeshBoundingBox(TR::StaticMesh *sm)
+	{
+		Box box;
+		sm->getBox(true, box);
+		
+		TR::Mesh *boundingBox = (TR::Mesh *) malloc(sizeof(TR::Mesh));
+		boundingBox->fCount = 12;
+		boundingBox->faces = (TR::Face *)malloc(sizeof(TR::Face)*boundingBox->fCount);
+
+		boundingBox->vCount = 8;
+		boundingBox->vertices = (TR::Mesh::Vertex *)malloc(sizeof(TR::Mesh::Vertex)*boundingBox->vCount);
+
+		boundingBox->vertices[0].coord.x=box.min.x;
+		boundingBox->vertices[0].coord.y=box.min.y;
+		boundingBox->vertices[0].coord.z=box.min.z;
+
+		boundingBox->vertices[1].coord.x=box.min.x;
+		boundingBox->vertices[1].coord.y=box.max.y;
+		boundingBox->vertices[1].coord.z=box.min.z;
+
+		boundingBox->vertices[2].coord.x=box.max.x;
+		boundingBox->vertices[2].coord.y=box.max.y;
+		boundingBox->vertices[2].coord.z=box.min.z;
+
+		boundingBox->vertices[3].coord.x=box.max.x;
+		boundingBox->vertices[3].coord.y=box.min.y;
+		boundingBox->vertices[3].coord.z=box.min.z;
+
+		boundingBox->vertices[4].coord.x=box.min.x;
+		boundingBox->vertices[4].coord.y=box.min.y;
+		boundingBox->vertices[4].coord.z=box.max.z;
+
+		boundingBox->vertices[5].coord.x=box.min.x;
+		boundingBox->vertices[5].coord.y=box.max.y;
+		boundingBox->vertices[5].coord.z=box.max.z;
+
+		boundingBox->vertices[6].coord.x=box.max.x;
+		boundingBox->vertices[6].coord.y=box.max.y;
+		boundingBox->vertices[6].coord.z=box.max.z;
+		
+		boundingBox->vertices[7].coord.x=box.max.x;
+		boundingBox->vertices[7].coord.y=box.min.y;
+		boundingBox->vertices[7].coord.z=box.max.z;
+
+		boundingBox->faces[0].triangle=1;
+		boundingBox->faces[0].vertices[0]=2;
+		boundingBox->faces[0].vertices[1]=1;
+		boundingBox->faces[0].vertices[2]=0;
+
+		boundingBox->faces[1].triangle=1;
+		boundingBox->faces[1].vertices[0]=0;
+		boundingBox->faces[1].vertices[1]=3;
+		boundingBox->faces[1].vertices[2]=2;
+
+		boundingBox->faces[2].triangle=1;
+		boundingBox->faces[2].vertices[0]=2;
+		boundingBox->faces[2].vertices[1]=3;
+		boundingBox->faces[2].vertices[2]=7;
+
+		boundingBox->faces[3].triangle=1;
+		boundingBox->faces[3].vertices[0]=7;
+		boundingBox->faces[3].vertices[1]=6;
+		boundingBox->faces[3].vertices[2]=2;
+
+		boundingBox->faces[4].triangle=1;
+		boundingBox->faces[4].vertices[0]=6;
+		boundingBox->faces[4].vertices[1]=7;
+		boundingBox->faces[4].vertices[2]=4;
+
+		boundingBox->faces[5].triangle=1;
+		boundingBox->faces[5].vertices[0]=4;
+		boundingBox->faces[5].vertices[1]=5;
+		boundingBox->faces[5].vertices[2]=6;
+
+		boundingBox->faces[6].triangle=1;
+		boundingBox->faces[6].vertices[0]=4;
+		boundingBox->faces[6].vertices[1]=0;
+		boundingBox->faces[6].vertices[2]=5;
+
+		boundingBox->faces[7].triangle=1;
+		boundingBox->faces[7].vertices[0]=0;
+		boundingBox->faces[7].vertices[1]=1;
+		boundingBox->faces[7].vertices[2]=5;
+
+		boundingBox->faces[8].triangle=1;
+		boundingBox->faces[8].vertices[0]=7;
+		boundingBox->faces[8].vertices[1]=3;
+		boundingBox->faces[8].vertices[2]=0;
+
+		boundingBox->faces[9].triangle=1;
+		boundingBox->faces[9].vertices[0]=0;
+		boundingBox->faces[9].vertices[1]=4;
+		boundingBox->faces[9].vertices[2]=7;
+
+		boundingBox->faces[10].triangle=1;
+		boundingBox->faces[10].vertices[0]=6;
+		boundingBox->faces[10].vertices[1]=5;
+		boundingBox->faces[10].vertices[2]=1;
+
+		boundingBox->faces[11].triangle=1;
+		boundingBox->faces[11].vertices[0]=1;
+		boundingBox->faces[11].vertices[1]=2;
+		boundingBox->faces[11].vertices[2]=6;
+
+		return boundingBox;
+	}
+
 	struct SM64SurfaceObject* marioLoadRoomMeshes(int roomId, int *room_meshes_count)
 	{
 		TR::Room &room = level->rooms[roomId];
@@ -1449,9 +1556,9 @@ struct Mario : Lara
 		{
 			TR::Room::Mesh &m  = room.meshes[j];
 			TR::StaticMesh *sm = &level->staticMeshes[m.meshIndex];
-			if (sm->flags != 2 || !level->meshOffsets[sm->mesh]) {
-				continue;
-			}
+			// if (sm->flags != 2 || !level->meshOffsets[sm->mesh]) {
+			// 	continue;
+			// }
 
 			// define the surface object
 			struct SM64SurfaceObject obj;
@@ -1466,135 +1573,32 @@ struct Mario : Lara
 
 			switch(level->id)
 			{
-			case TR::LevelID::LVL_TR1_8B:
-				switch (m.meshID)
+			case TR::LevelID::LVL_TR1_GYM:
+				switch (m.meshIndex)
 				{
-				case 34: //Gates at the beginning
-					Box box;
-					sm->getBox(true, m.rotation, box);
-					
-					boundingBox = (TR::Mesh *) malloc(sizeof(TR::Mesh));
-					boundingBox->fCount = 12;
-					boundingBox->faces = (TR::Face *)malloc(sizeof(TR::Face)*boundingBox->fCount);
-
-					boundingBox->vCount = 8;
-					boundingBox->vertices = (TR::Mesh::Vertex *)malloc(sizeof(TR::Mesh::Vertex)*boundingBox->vCount);
-
-					// const int boundingBoxPad = 20;
-					// if(box.min.x==box.max.x) {
-					// 	box.min.x-=boundingBoxPad;
-					// 	box.max.x+=boundingBoxPad;
-					// }
-
-					// if(box.min.y==box.max.y) {
-					// 	box.min.y-=boundingBoxPad;
-					// 	box.max.y+=boundingBoxPad;
-					// }
-
-					// if(box.min.z==box.max.z) {
-					// 	box.min.z-=boundingBoxPad;
-					// 	box.max.z+=boundingBoxPad;
-					// }
-
-					boundingBox->vertices[0].coord.x=box.min.x;
-					boundingBox->vertices[0].coord.y=box.min.y;
-					boundingBox->vertices[0].coord.z=box.min.z;
-
-					boundingBox->vertices[1].coord.x=box.min.x;
-					boundingBox->vertices[1].coord.y=box.max.y;
-					boundingBox->vertices[1].coord.z=box.min.z;
-
-					boundingBox->vertices[2].coord.x=box.max.x;
-					boundingBox->vertices[2].coord.y=box.max.y;
-					boundingBox->vertices[2].coord.z=box.min.z;
-
-					boundingBox->vertices[3].coord.x=box.max.x;
-					boundingBox->vertices[3].coord.y=box.min.y;
-					boundingBox->vertices[3].coord.z=box.min.z;
-
-					boundingBox->vertices[4].coord.x=box.min.x;
-					boundingBox->vertices[4].coord.y=box.min.y;
-					boundingBox->vertices[4].coord.z=box.max.z;
-
-					boundingBox->vertices[5].coord.x=box.min.x;
-					boundingBox->vertices[5].coord.y=box.max.y;
-					boundingBox->vertices[5].coord.z=box.max.z;
-
-					boundingBox->vertices[6].coord.x=box.max.x;
-					boundingBox->vertices[6].coord.y=box.max.y;
-					boundingBox->vertices[6].coord.z=box.max.z;
-					
-					boundingBox->vertices[7].coord.x=box.max.x;
-					boundingBox->vertices[7].coord.y=box.min.y;
-					boundingBox->vertices[7].coord.z=box.max.z;
-
-					boundingBox->faces[0].triangle=1;
-					boundingBox->faces[0].vertices[0]=2;
-					boundingBox->faces[0].vertices[1]=1;
-					boundingBox->faces[0].vertices[2]=0;
-
-					boundingBox->faces[1].triangle=1;
-					boundingBox->faces[1].vertices[0]=0;
-					boundingBox->faces[1].vertices[1]=3;
-					boundingBox->faces[1].vertices[2]=2;
-
-					boundingBox->faces[2].triangle=1;
-					boundingBox->faces[2].vertices[0]=2;
-					boundingBox->faces[2].vertices[1]=3;
-					boundingBox->faces[2].vertices[2]=7;
-
-					boundingBox->faces[3].triangle=1;
-					boundingBox->faces[3].vertices[0]=7;
-					boundingBox->faces[3].vertices[1]=6;
-					boundingBox->faces[3].vertices[2]=2;
-
-					boundingBox->faces[4].triangle=1;
-					boundingBox->faces[4].vertices[0]=6;
-					boundingBox->faces[4].vertices[1]=7;
-					boundingBox->faces[4].vertices[2]=4;
-
-					boundingBox->faces[5].triangle=1;
-					boundingBox->faces[5].vertices[0]=4;
-					boundingBox->faces[5].vertices[1]=5;
-					boundingBox->faces[5].vertices[2]=6;
-
-					boundingBox->faces[6].triangle=1;
-					boundingBox->faces[6].vertices[0]=5;
-					boundingBox->faces[6].vertices[1]=4;
-					boundingBox->faces[6].vertices[2]=0;
-
-					boundingBox->faces[7].triangle=1;
-					boundingBox->faces[7].vertices[0]=0;
-					boundingBox->faces[7].vertices[1]=1;
-					boundingBox->faces[7].vertices[2]=5;
-
-					boundingBox->faces[8].triangle=1;
-					boundingBox->faces[8].vertices[0]=7;
-					boundingBox->faces[8].vertices[1]=3;
-					boundingBox->faces[8].vertices[2]=0;
-
-					boundingBox->faces[9].triangle=1;
-					boundingBox->faces[9].vertices[0]=0;
-					boundingBox->faces[9].vertices[1]=4;
-					boundingBox->faces[9].vertices[2]=7;
-
-					boundingBox->faces[10].triangle=1;
-					boundingBox->faces[10].vertices[0]=6;
-					boundingBox->faces[10].vertices[1]=5;
-					boundingBox->faces[10].vertices[2]=1;
-
-					boundingBox->faces[11].triangle=1;
-					boundingBox->faces[11].vertices[0]=1;
-					boundingBox->faces[11].vertices[1]=2;
-					boundingBox->faces[11].vertices[2]=6;					
-					
+				case 7: //harp
+				case 8: //piano	
+				case 13: //handcart
+				//case 15: //stair horizontal rails
+				//case 18: //stair rails pillars
+					boundingBox = generateMeshBoundingBox(sm);					
 					break;
 				}
-
+			case TR::LevelID::LVL_TR1_8B:
+				switch (m.meshIndex)
+				{
+				case 10: // Iron Bars with only 1 face										
+					boundingBox = generateMeshBoundingBox(sm);
+					break;
+				}
 			}
-
+			
 			if(boundingBox)
 				d=boundingBox;
+			else if(d->fCount==0){
+				boundingBox = generateMeshBoundingBox(sm);
+				d=boundingBox;
+			}
 
 			// increment the surface count for this
 			for (int k = 0; k < d->fCount; k++)
@@ -1628,6 +1632,8 @@ struct Mario : Lara
 			{
 				free(boundingBox->faces);
 				free(boundingBox->vertices);
+				free(boundingBox);
+				boundingBox=NULL;
 			}
 
 			meshes[(*room_meshes_count)++]=obj;

--- a/src/mario.h
+++ b/src/mario.h
@@ -1612,11 +1612,20 @@ struct Mario : Lara
 				// 	break;
 				}
 				break;
+			case TR::LevelID::LVL_TR1_10B: //Atlantis
+				switch (m.meshIndex)
+				{
+				case 0:	// weird flesh 1 surface walls
+				case 1:	// weird flesh 1 surface walls
+					boundingBox = generateMeshBoundingBox(sm);
+					break;
+				}
+				break;
 			}
 			
 			if(boundingBox)
 				d=boundingBox;
-			else if(d->fCount==0 || sm->vbox.minX==sm->vbox.maxX || sm->vbox.minY==sm->vbox.maxY || sm->vbox.minZ==sm->vbox.maxZ){
+			else if(d->fCount<2 || sm->vbox.minX==sm->vbox.maxX || sm->vbox.minY==sm->vbox.maxY || sm->vbox.minZ==sm->vbox.maxZ){
 				boundingBox = generateMeshBoundingBox(sm);
 				d=boundingBox;
 			}

--- a/src/mario.h
+++ b/src/mario.h
@@ -1584,18 +1584,25 @@ struct Mario : Lara
 					boundingBox = generateMeshBoundingBox(sm);					
 					break;
 				}
-			case TR::LevelID::LVL_TR1_8B:
+			case TR::LevelID::LVL_TR1_1: //Caves
 				switch (m.meshIndex)
 				{
-				case 10: // Iron Bars with only 1 face										
-					boundingBox = generateMeshBoundingBox(sm);
-					break;
+				// case 2: //wood fence blocking path to exit - solved by viewbox size
+				// 	boundingBox = generateMeshBoundingBox(sm);					
+				// 	break;
+				}
+			case TR::LevelID::LVL_TR1_8B: //Obelisk of Khamoon
+				switch (m.meshIndex)
+				{
+				// case 10: // Iron Bars with only 1 face - solved by viewbox size										
+				// 	boundingBox = generateMeshBoundingBox(sm);
+				// 	break;
 				}
 			}
 			
 			if(boundingBox)
 				d=boundingBox;
-			else if(d->fCount==0){
+			else if(d->fCount==0 || sm->vbox.minX==sm->vbox.maxX || sm->vbox.minY==sm->vbox.maxY || sm->vbox.minZ==sm->vbox.maxZ){
 				boundingBox = generateMeshBoundingBox(sm);
 				d=boundingBox;
 			}

--- a/src/mario.h
+++ b/src/mario.h
@@ -1579,8 +1579,6 @@ struct Mario : Lara
 				case 7: //harp
 				case 8: //piano	
 				case 13: //handcart
-				//case 15: //stair horizontal rails
-				//case 18: //stair rails pillars
 					boundingBox = generateMeshBoundingBox(sm);					
 					break;
 				}
@@ -1588,9 +1586,25 @@ struct Mario : Lara
 			case TR::LevelID::LVL_TR1_1: //Caves
 				switch (m.meshIndex)
 				{
+				case 0:	// branches
+				case 1:	// branches	
+				case 7:	// ice stalactite
+					continue;
 				// case 2: //wood fence blocking path to exit - solved by viewbox size
 				// 	boundingBox = generateMeshBoundingBox(sm);					
 				// 	break;
+				}
+				break;
+			case TR::LevelID::LVL_TR1_2: //City of Vilcabamba
+				switch (m.meshIndex)
+				{
+				case 0:	// branches	
+				case 1:	// branches	
+					continue;
+				case 3: // barn animal food holder - Mario can get stuck on it.
+				case 7:	// Stone Statues - Mario can clip through them and fall into the void.
+					boundingBox = generateMeshBoundingBox(sm);
+					break;
 				}
 				break;
 			case TR::LevelID::LVL_TR1_3A: //The Lost Valley

--- a/src/mario.h
+++ b/src/mario.h
@@ -1576,9 +1576,16 @@ struct Mario : Lara
 			case TR::LevelID::LVL_TR1_GYM:
 				switch (m.meshIndex)
 				{
-				case 7: //harp
-				case 8: //piano	
-				case 13: //handcart
+				case 0:	// plant - Mario can get stuck
+				case 1:	// plant - Mario can get stuck
+				case 2: // plant - Mario can get stuck
+				case 3: // plant - Mario can get stuck
+				case 4: // branches - Mario can get stuck
+					continue;
+				case 7: //harp - Mario can get stuck
+				case 8: //piano	- Martio can get stuck
+				case 11: //pedestal - Mario can get stuck between it and the columns
+				case 13: //handcart - Mario can get stuck
 					boundingBox = generateMeshBoundingBox(sm);					
 					break;
 				}
@@ -1586,9 +1593,9 @@ struct Mario : Lara
 			case TR::LevelID::LVL_TR1_1: //Caves
 				switch (m.meshIndex)
 				{
-				case 0:	// branches
-				case 1:	// branches	
-				case 7:	// ice stalactite
+				case 0:	// branches - Mario stumbles
+				case 1:	// branches	- Mario stumbles
+				case 7:	// ice stalactite - Mario stumbles
 					continue;
 				// case 2: //wood fence blocking path to exit - solved by viewbox size
 				// 	boundingBox = generateMeshBoundingBox(sm);					
@@ -1598,8 +1605,8 @@ struct Mario : Lara
 			case TR::LevelID::LVL_TR1_2: //City of Vilcabamba
 				switch (m.meshIndex)
 				{
-				case 0:	// branches	
-				case 1:	// branches	
+				case 0:	// branches - Mario stumbles
+				case 1:	// branches - Mario stumbles
 					continue;
 				case 3: // barn animal food holder - Mario can get stuck on it.
 				case 7:	// Stone Statues - Mario can clip through them and fall into the void.
@@ -1610,18 +1617,18 @@ struct Mario : Lara
 			case TR::LevelID::LVL_TR1_3A: //The Lost Valley
 				switch (m.meshIndex)
 				{
-				case 0:	// branches
-				case 1:	// branches
-				case 2: // tree/bushes
-				case 3: // tree/bushes
-				case 4: // tree/bushes
-				case 5: // tree/bushes
+				case 0:	// branches - Mario stumbles
+				case 1:	// branches - Mario stumbles
+				case 2: // tree/bushes - Mario can get stuck
+				case 3: // tree/bushes - Mario can get stuck
+				case 4: // tree/bushes - Mario can get stuck
+				case 5: // tree/bushes - Mario can get stuck
 				case 6: // dead tree trunk get mario stuck. we will ignore it.
-				case 7: // trees
-				case 8: // trees
+				case 7: // trees - Mario can get stuck
+				case 8: // trees - Mario can get stuck
 					continue;
-				case 12: // skeleton
-				case 13: // skeleton
+				case 12: // skeleton - Mario stumbles
+				case 13: // skeleton - Mario stumbles
 					boundingBox = generateMeshBoundingBox(sm);
 					break;
 				}

--- a/src/mario.h
+++ b/src/mario.h
@@ -1050,7 +1050,7 @@ struct Mario : Lara
 		if (needFlip) {
 			game->flipMap();
 			game->setEffect(this, effect);
-			marioUpdateRoom(TR::NO_ROOM);
+			marioUpdateRoom(TR::NO_ROOM, true);
 		}
 	}
 
@@ -1523,8 +1523,12 @@ struct Mario : Lara
 		
 	}
 
-	void marioUpdateRoom(int oldRoom)
+	void marioUpdateRoom(int oldRoom, bool forceRefresh=false)
 	{
+		if(forceRefresh){
+			previousLoadedRoomsCount=0;
+		}
+
 		TR::Room &myRoom = getRoom();
 
 		// Set the water level to SM64

--- a/src/marioMacros.h
+++ b/src/marioMacros.h
@@ -39,6 +39,11 @@ extern "C" {
 		}}; \
 	}
 
+#define CONVERT_DEBUG_FACE_COORDINATES(src) \
+	vec3(src.v1[0]*IMARIO_SCALE, -src.v1[1]*IMARIO_SCALE, -src.v1[2]*IMARIO_SCALE), \
+	vec3(src.v2[0]*IMARIO_SCALE, -src.v2[1]*IMARIO_SCALE, -src.v2[2]*IMARIO_SCALE), \
+	vec3(src.v3[0]*IMARIO_SCALE, -src.v3[1]*IMARIO_SCALE, -src.v3[2]*IMARIO_SCALE)
+
 #define COUNT_ROOM_SECTORS(level, surfaces_count, room) \
 	COUNT_ROOM_SECTORS_UP(level, surfaces_count, room);\
 	COUNT_ROOM_SECTORS_DOWN(level, surfaces_count, room);


### PR DESCRIPTION
Added support for the new room management in SM64.

Multiple marios will have their own activated rooms logic (including the doppelganger).

Moved visible rooms logic to allow reusing it for the doppelganger.

Implemented new visual debbuger logic which is now completely contained in debug.h and does less conversions.

Implemented the functionality for replacing some static meshes from their geometry to bounding boxes. This is automatically applied to static meshes that are one plane only (which mario wouldn't colide).

Implemented new room flip mode that switches rooms in the rooms array inside SM64 without needing to reload data.

Big plane underneath mario hack has been moved into sm64.