### PR TITLE
Implemented clipper boxs, extracted map management from mario.h and more.

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,10 +3,11 @@
         {
             "name": "Win32",
             "includePath": [
-                "${workspaceFolder}/src/libs/","${workspaceFolder}/src/","C:/msys64/mingw64/include"
+                "${workspaceFolder}/src/libs/",
+                "${workspaceFolder}/src/",
+                "C:/msys64/mingw64/include"
             ],
             "defines": [
-                "_DEBUG",
                 "UNICODE",
                 "_UNICODE",
                 "DWIN32",
@@ -19,8 +20,8 @@
                 "GEOMETRY_EXPORT"
             ],
             "compilerPath": "C:\\msys64\\mingw64\\bin\\g++.exe",
-            "cStandard": "c99",
-            "cppStandard": "c++11",
+            "cStandard": "c17",
+            "cppStandard": "c++20",
             "intelliSenseMode": "clang-x64",
             "configurationProvider": "ms-vscode.makefile-tools"
         }

--- a/src/controller.h
+++ b/src/controller.h
@@ -5,6 +5,7 @@
 #include "frustum.h"
 #include "mesh.h"
 #include "animation.h"
+#include "levelsm64.h"
 
 #define GRAVITY     6.0f
 #define SPRITE_FPS  10.0f
@@ -63,6 +64,7 @@ struct IGame {
     virtual void         applySettings(const Core::Settings &settings)  {}
 
     virtual TR::Level*   getLevel()     { return NULL; }
+    virtual LevelSM64*   getLevelSM64() { return NULL; }
     virtual MeshBuilder* getMesh()      { return NULL; }
     virtual ICamera*     getCamera(int index = -1)  { return NULL; }
     virtual Controller*  getLara(int index = 0)     { return NULL; }
@@ -106,13 +108,14 @@ struct IGame {
     virtual void getCurrentAndAdjacentRooms(int *roomsList, int *roomsCount, int currentRoomIndex, int to, int maxDepth, int count=0){}
 };
 
-struct Controller {
+struct Controller : IController {
 
     static Controller *first;
     Controller  *next;
 
     IGame       *game;
     TR::Level   *level;
+    LevelSM64   *levelSM64;
     int         entity;
     
     Animation   animation;
@@ -235,7 +238,7 @@ struct Controller {
         return false;
     }
 
-    void getFloorInfo(int roomIndex, const vec3 &pos, TR::Level::FloorInfo &info) const {
+    virtual void getFloorInfo(int roomIndex, const vec3 &pos, TR::Level::FloorInfo &info) const {
         int x = int(pos.x);
         int y = int(pos.y);
         int z = int(pos.z);

--- a/src/controller.h
+++ b/src/controller.h
@@ -164,7 +164,7 @@ struct Controller : IController {
 
     bool isMario;
 
-    Controller(IGame *game, int entity) : next(NULL), game(game), level(game->getLevel()), entity(entity), animation(level, getModel(), level->entities[entity].flags.smooth), state(animation.state), invertAim(false), layers(0), explodeMask(0), explodeParts(0), lastPos(0) {
+    Controller(IGame *game, int entity) : next(NULL), game(game), level(game->getLevel()), levelSM64(game->getLevelSM64()), entity(entity), animation(level, getModel(), level->entities[entity].flags.smooth), state(animation.state), invertAim(false), layers(0), explodeMask(0), explodeParts(0), lastPos(0) {
         isMario = false;
 
         const TR::Entity &e = getEntity();

--- a/src/controller.h
+++ b/src/controller.h
@@ -105,7 +105,6 @@ struct IGame {
     virtual Sound::Sample* playSound(int id, const vec3 &pos = vec3(0.0f), int flags = 0) const { return NULL; }
     virtual void playTrack(uint8 track, bool background = false) {}
     virtual void stopTrack()                                     {}
-    virtual void getCurrentAndAdjacentRooms(int *roomsList, int *roomsCount, int currentRoomIndex, int to, int maxDepth, int count=0){}
 };
 
 struct Controller : IController {

--- a/src/core.h
+++ b/src/core.h
@@ -43,6 +43,10 @@
 
     //#define _NAPI_SOCKET
 
+    // M_PI support
+    #define _USE_MATH_DEFINES
+    #include <cmath>
+
     #include <windows.h>
 
     #undef OS_PTHREAD_MT

--- a/src/debug.h
+++ b/src/debug.h
@@ -208,6 +208,32 @@ namespace Debug {
             glLineWidth(1.0f);
         }
 
+        void staticface(const vec3 &a, const vec3 &b, const vec3 &c, const vec3 &d, const vec4 &linecolor, const vec4 &facecolor) {
+            glLineWidth(2.0f);
+            //Core::setDepthTest(false);
+            glColor4fv((GLfloat*)&linecolor);
+            glBegin(GL_LINES);                
+                glVertex3fv((GLfloat*)&a);
+                glVertex3fv((GLfloat*)&b);
+                glVertex3fv((GLfloat*)&b);
+                glVertex3fv((GLfloat*)&c);
+                glVertex3fv((GLfloat*)&c);
+                glVertex3fv((GLfloat*)&d);
+                glVertex3fv((GLfloat*)&d);
+                glVertex3fv((GLfloat*)&a);
+            glEnd();
+
+            glColor4fv((GLfloat*)&facecolor);
+            glBegin(GL_QUADS);                
+                glVertex3fv((GLfloat*)&a);
+                glVertex3fv((GLfloat*)&b);
+                glVertex3fv((GLfloat*)&c);
+                glVertex3fv((GLfloat*)&d);                
+            glEnd();
+            //Core::setDepthTest(true);
+            glLineWidth(1.0f);
+        }
+
         void textColor(const vec2 &pos, const vec4 &color, const char *str) {
             glMatrixMode(GL_MODELVIEW);
             glPushMatrix();
@@ -642,6 +668,60 @@ namespace Debug {
             }
 
             Core::setDepthTest(true);            
+        }
+
+        void sm64debugrooms(TR::Level *level, int roomIndex) {
+
+            TR::Room &room = level->rooms[roomIndex];
+            TR::Room::Data &d = room.data;
+
+            printf("room: %d\n", roomIndex);
+            Core::setDepthTest(false); 
+            // Count the number of static surface triangles
+            for (int j = 0; j < d.fCount; j++)
+            {
+                TR::Face &f = d.faces[j];
+                if (!f.triangle)
+                {
+                    Debug::Draw::staticface(
+                        vec3((float)d.vertices[f.vertices[0]].pos.x+room.info.x, (float)d.vertices[f.vertices[0]].pos.y, (float)d.vertices[f.vertices[0]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[1]].pos.x+room.info.x, (float)d.vertices[f.vertices[1]].pos.y, (float)d.vertices[f.vertices[1]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[2]].pos.x+room.info.x, (float)d.vertices[f.vertices[2]].pos.y, (float)d.vertices[f.vertices[2]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[3]].pos.x+room.info.x, (float)d.vertices[f.vertices[3]].pos.y, (float)d.vertices[f.vertices[3]].pos.z+room.info.z),
+                        vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
+
+                    
+                    char buf[255];
+                    sprintf(buf, "Room: %d Id: %d", roomIndex, j);
+                    Debug::Draw::text(
+                        vec3(
+                            (d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+d.vertices[f.vertices[3]].pos.x+(4*room.info.x))/4.0f,
+                            (d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y+d.vertices[f.vertices[3]].pos.y)/4.0f,
+                            (d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+d.vertices[f.vertices[3]].pos.z+(4*room.info.z))/4.0f
+                            ), vec4(0.5, 0.5, 1.0, 1), buf);
+                }
+                else
+                {
+                    Debug::Draw::staticface(
+                        vec3((float)d.vertices[f.vertices[0]].pos.x+room.info.x, (float)d.vertices[f.vertices[0]].pos.y, (float)d.vertices[f.vertices[0]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[1]].pos.x+room.info.x, (float)d.vertices[f.vertices[1]].pos.y, (float)d.vertices[f.vertices[1]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[2]].pos.x+room.info.x, (float)d.vertices[f.vertices[2]].pos.y, (float)d.vertices[f.vertices[2]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[3]].pos.x+room.info.x, (float)d.vertices[f.vertices[3]].pos.y, (float)d.vertices[f.vertices[3]].pos.z+room.info.z),
+                        vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
+
+                    
+                    char buf[255];
+                    sprintf(buf, "Room: %d Id: %d", roomIndex, j);
+                    Debug::Draw::text(
+                        vec3(
+                            (d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+(3*room.info.x))/3.0f,
+                            (d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y)/3.0f,
+                            (d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+(3*room.info.z))/3.0f
+                            ), vec4(0.5, 0.5, 1.0, 1), buf);
+                }
+                
+            }
+            Core::setDepthTest(true);                        
         }
 
         void lights(const TR::Level &level, int room, Controller *lara) {

--- a/src/debug.h
+++ b/src/debug.h
@@ -638,6 +638,9 @@ namespace Debug {
                     case EXTERNAL_SURFACE_TYPE_DYNAMIC_OBJECT:
                         Debug::Draw::triangle(CONVERT_DEBUG_FACE_COORDINATES(faces[i]), vec4(0.9f, 0.0f, 0.9f, 0.5f), vec4(0.9f, 0.0f, 0.9f, 0.3f));
                         break;
+                    case EXTERNAL_SURFACE_TYPE_WALL_CLIPPER:
+                        Debug::Draw::triangle(CONVERT_DEBUG_FACE_COORDINATES(faces[i]), vec4(0.9f, 0.0f, 0.0f, 0.5f), vec4(0.9f, 0.0f, 0.0f, 0.3f));
+                        break;
                 }
             }
 
@@ -670,56 +673,55 @@ namespace Debug {
             Core::setDepthTest(true);            
         }
 
-        void sm64debugrooms(TR::Level *level, int roomIndex) {
+        void sm64debugrooms(TR::Level *level, int *roomslist, int roomscount) {
 
-            TR::Room &room = level->rooms[roomIndex];
-            TR::Room::Data &d = room.data;
-
-            printf("room: %d\n", roomIndex);
-            Core::setDepthTest(false); 
-            // Count the number of static surface triangles
-            for (int j = 0; j < d.fCount; j++)
+            for(int roomIndex=0; roomIndex<roomscount; roomIndex++)
             {
-                TR::Face &f = d.faces[j];
-                if (!f.triangle)
-                {
-                    Debug::Draw::staticface(
-                        vec3((float)d.vertices[f.vertices[0]].pos.x+room.info.x, (float)d.vertices[f.vertices[0]].pos.y, (float)d.vertices[f.vertices[0]].pos.z+room.info.z),
-                        vec3((float)d.vertices[f.vertices[1]].pos.x+room.info.x, (float)d.vertices[f.vertices[1]].pos.y, (float)d.vertices[f.vertices[1]].pos.z+room.info.z),
-                        vec3((float)d.vertices[f.vertices[2]].pos.x+room.info.x, (float)d.vertices[f.vertices[2]].pos.y, (float)d.vertices[f.vertices[2]].pos.z+room.info.z),
-                        vec3((float)d.vertices[f.vertices[3]].pos.x+room.info.x, (float)d.vertices[f.vertices[3]].pos.y, (float)d.vertices[f.vertices[3]].pos.z+room.info.z),
-                        vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
+                TR::Room &room = level->rooms[roomslist[roomIndex]];
+                TR::Room::Data &d = room.data;
 
-                    
-                    char buf[255];
-                    sprintf(buf, "Room: %d Id: %d", roomIndex, j);
-                    Debug::Draw::text(
-                        vec3(
-                            (d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+d.vertices[f.vertices[3]].pos.x+(4*room.info.x))/4.0f,
-                            (d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y+d.vertices[f.vertices[3]].pos.y)/4.0f,
-                            (d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+d.vertices[f.vertices[3]].pos.z+(4*room.info.z))/4.0f
-                            ), vec4(0.5, 0.5, 1.0, 1), buf);
-                }
-                else
+                Core::setDepthTest(false); 
+                for (int j = 0; j < d.fCount; j++)
                 {
-                    Debug::Draw::staticface(
-                        vec3((float)d.vertices[f.vertices[0]].pos.x+room.info.x, (float)d.vertices[f.vertices[0]].pos.y, (float)d.vertices[f.vertices[0]].pos.z+room.info.z),
-                        vec3((float)d.vertices[f.vertices[1]].pos.x+room.info.x, (float)d.vertices[f.vertices[1]].pos.y, (float)d.vertices[f.vertices[1]].pos.z+room.info.z),
-                        vec3((float)d.vertices[f.vertices[2]].pos.x+room.info.x, (float)d.vertices[f.vertices[2]].pos.y, (float)d.vertices[f.vertices[2]].pos.z+room.info.z),
-                        vec3((float)d.vertices[f.vertices[3]].pos.x+room.info.x, (float)d.vertices[f.vertices[3]].pos.y, (float)d.vertices[f.vertices[3]].pos.z+room.info.z),
-                        vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
+                    TR::Face &f = d.faces[j];
+                    if (!f.triangle)
+                    {
+                        Debug::Draw::staticface(
+                            vec3((float)d.vertices[f.vertices[0]].pos.x+room.info.x, (float)d.vertices[f.vertices[0]].pos.y, (float)d.vertices[f.vertices[0]].pos.z+room.info.z),
+                            vec3((float)d.vertices[f.vertices[1]].pos.x+room.info.x, (float)d.vertices[f.vertices[1]].pos.y, (float)d.vertices[f.vertices[1]].pos.z+room.info.z),
+                            vec3((float)d.vertices[f.vertices[2]].pos.x+room.info.x, (float)d.vertices[f.vertices[2]].pos.y, (float)d.vertices[f.vertices[2]].pos.z+room.info.z),
+                            vec3((float)d.vertices[f.vertices[3]].pos.x+room.info.x, (float)d.vertices[f.vertices[3]].pos.y, (float)d.vertices[f.vertices[3]].pos.z+room.info.z),
+                            vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
 
-                    
-                    char buf[255];
-                    sprintf(buf, "Room: %d Id: %d", roomIndex, j);
-                    Debug::Draw::text(
-                        vec3(
-                            (d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+(3*room.info.x))/3.0f,
-                            (d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y)/3.0f,
-                            (d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+(3*room.info.z))/3.0f
-                            ), vec4(0.5, 0.5, 1.0, 1), buf);
+                        
+                        char buf[255];
+                        sprintf(buf, "Room: %d Id: %d", roomslist[roomIndex], j);
+                        Debug::Draw::text(
+                            vec3(
+                                (d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+d.vertices[f.vertices[3]].pos.x+(4*room.info.x))/4.0f,
+                                (d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y+d.vertices[f.vertices[3]].pos.y)/4.0f,
+                                (d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+d.vertices[f.vertices[3]].pos.z+(4*room.info.z))/4.0f
+                                ), vec4(0.5, 0.5, 1.0, 1), buf);
+                    }
+                    else
+                    {
+                        Debug::Draw::triangle(
+                            vec3((float)d.vertices[f.vertices[0]].pos.x+room.info.x, (float)d.vertices[f.vertices[0]].pos.y, (float)d.vertices[f.vertices[0]].pos.z+room.info.z),
+                            vec3((float)d.vertices[f.vertices[1]].pos.x+room.info.x, (float)d.vertices[f.vertices[1]].pos.y, (float)d.vertices[f.vertices[1]].pos.z+room.info.z),
+                            vec3((float)d.vertices[f.vertices[2]].pos.x+room.info.x, (float)d.vertices[f.vertices[2]].pos.y, (float)d.vertices[f.vertices[2]].pos.z+room.info.z),
+                            vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
+
+                        
+                        char buf[255];
+                        sprintf(buf, "Room: %d Id: %d", roomslist[roomIndex], j);
+                        Debug::Draw::text(
+                            vec3(
+                                (d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+(3*room.info.x))/3.0f,
+                                (d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y)/3.0f + (roomslist[roomIndex]==50 ? 20 : 0),
+                                (d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+(3*room.info.z))/3.0f
+                                ), vec4(0.5, 0.5, 1.0, 1), buf);
+                    }                    
                 }
-                
             }
             Core::setDepthTest(true);                        
         }

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -2550,7 +2550,7 @@ struct MarioDoppelganger: Enemy
 		{
             int nearRooms[256];
             int nearRoomsCount=0;
-            game->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
+            levelSM64->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
 			marioId = sm64_mario_create(pos.x/MARIO_SCALE, -pos.y/MARIO_SCALE, -pos.z/MARIO_SCALE, 0, 0, 0, 0, nearRooms, nearRoomsCount);
 			sm64_set_mario_state(marioId, 0); // remove cap
 			target = (Character*)game->getLara(0);
@@ -2560,7 +2560,7 @@ struct MarioDoppelganger: Enemy
         {
             int nearRooms[256];
             int nearRoomsCount=0;
-            game->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
+            levelSM64->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
             sm64_level_update_loaded_rooms_list(marioId, nearRooms, nearRoomsCount);
         }
 

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -2548,10 +2548,7 @@ struct MarioDoppelganger: Enemy
 	{
 		if (!target)
 		{
-            int nearRooms[256];
-            int nearRoomsCount=0;
-            levelSM64->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
-			marioId = sm64_mario_create(pos.x/MARIO_SCALE, -pos.y/MARIO_SCALE, -pos.z/MARIO_SCALE, 0, 0, 0, 0, nearRooms, nearRoomsCount);
+            marioId = levelSM64->createMarioInstance(getRoomIndex(), pos);
 			sm64_set_mario_state(marioId, 0); // remove cap
 			target = (Character*)game->getLara(0);
 		}

--- a/src/format.h
+++ b/src/format.h
@@ -1583,7 +1583,7 @@ namespace TR {
         };
 
         Limit SWITCH_MARIO = {
-            0, 376, 30,     ::Box(vec3(-200, 0, 290), vec3(200, 0, 512)), true, false
+            0, 376, 30,     ::Box(vec3(-200, 0, 270), vec3(200, 0, 512)), true, false
         };
 
         Limit PICKUP = {

--- a/src/format.h
+++ b/src/format.h
@@ -7029,4 +7029,8 @@ namespace TR {
     }; // struct Level
 }
 
+struct IController {
+    virtual void getFloorInfo(int roomIndex, const vec3 &pos, TR::Level::FloorInfo &info) const {}
+};
+
 #endif

--- a/src/level.h
+++ b/src/level.h
@@ -1113,7 +1113,10 @@ struct Level : IGame {
         loadNextLevel();
     #endif
 
-        levelSM64->loadSM64Level(getLevel(), player);
+
+        levelSM64->loadSM64Level(getLevel(), player, player ? player->getRoomIndex() : 0);
+
+
         saveResult = SAVE_RESULT_SUCCESS;
         if (loadSlot != -1 && saveSlots[loadSlot].getLevelID() == level.id) {
             parseSaveSlot(saveSlots[loadSlot]);
@@ -1127,7 +1130,8 @@ struct Level : IGame {
 
     virtual ~Level() {
         UI::init(NULL);
-        delete levelSM64;
+        if(levelSM64!=NULL)
+            delete levelSM64;
         Network::stop();
 
         for (int i = 0; i < level.entitiesCount; i++)
@@ -3168,7 +3172,13 @@ struct Level : IGame {
             if(surfaceDebugger)
             {
                 Lara *lara = (Lara *)getLara(0);
-                Debug::Level::sm64debugrooms(&level, lara->getRoomIndex());
+
+                if(lara && levelSM64){
+                    int nearRooms[256];
+                    int nearRoomsCount=0;
+                    levelSM64->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, lara->getRoomIndex(), lara->getRoomIndex(), 0);
+                    Debug::Level::sm64debugrooms(&level, nearRooms, nearRoomsCount);
+                }
             }
             
             Core::setDepthTest(true);

--- a/src/level.h
+++ b/src/level.h
@@ -72,6 +72,8 @@ struct Level : IGame {
     bool skyIsVisible;
     bool paused;
 
+    bool surfaceDebugger=false;
+
     TR::LevelID nextLevel;
 
     TR::Effect::Type effect;
@@ -479,48 +481,6 @@ struct Level : IGame {
         if (players[1]->health <= 0.0f)
             return players[0];
         return (players[0]->pos - pos).length2() < (players[1]->pos - pos).length2() ? players[0] : players[1];
-    }
-
-    virtual void getCurrentAndAdjacentRooms(int *roomsList, int *roomsCount, int currentRoomIndex, int to, int maxDepth, int count=0) {
-        if (count>maxDepth) {
-            return;
-        }
-
-		// if we are starting to search we set all levels visibility to false
-		if(count==0)
-		{
-			for (int i = 0; i < getLevel()->roomsCount; i++)
-				getLevel()->rooms[i].flags.visible = false;
-		}
-
-		//Hardcoded exceptions to avoid invisible collisions
-		switch (getLevel()->id)
-		{
-		case TR::LVL_TR1_10B: //Atlantis
-			switch (currentRoomIndex)
-			{
-			case 47: //room with blocks and switches to trapdoors
-				if(to==84)
-					return;
-			}
-		}
-
-		count++;
-
-        TR::Room &room = getLevel()->rooms[to];
-
-		if(!room.flags.visible){
-			room.flags.visible = true;
-			roomsList[*roomsCount] = to;
-			*roomsCount+=1;
-		}
-
-		if(*roomsCount == 256)
-			return;
-
-		for (int i = 0; i < room.portalsCount; i++) {
-			getCurrentAndAdjacentRooms(roomsList, roomsCount, currentRoomIndex, room.portals[i].roomIndex, maxDepth, count);
-		}
     }
 
     virtual bool isCutscene() {
@@ -2484,6 +2444,10 @@ struct Level : IGame {
             }
             Input::down[ikF3] = false;
         }
+        if (Input::down[ikF4]) {
+            surfaceDebugger=!surfaceDebugger;
+            Input::down[ikF4] = false;
+        }
     #endif
     }
 
@@ -3199,6 +3163,12 @@ struct Level : IGame {
                     Debug::Level::sm64debug(players[i], &level);
                     break;
                 }
+            }
+
+            if(surfaceDebugger)
+            {
+                Lara *lara = (Lara *)getLara(0);
+                Debug::Level::sm64debugrooms(&level, lara->getRoomIndex());
             }
             
             Core::setDepthTest(true);

--- a/src/levelsm64.h
+++ b/src/levelsm64.h
@@ -227,7 +227,9 @@ struct LevelSM64
 			switch (meshIndex)
 			{
 				case 3: // barn animal food holder - Mario can get stuck on it.
+				case 4: // Meat holder - Thin geometry and mario can get stuck
 				case 7:	// Stone Statues - Mario can clip through them and fall into the void.
+				case 8: // Meat holder - Thin geometry and mario can get stuck
 					return MESH_LOADING_BOUNDING_BOX;
 				case 6: // platform with small statue - wihtout it mario falls into the void.
 					return MESH_LOADING_NORMAL;
@@ -240,19 +242,19 @@ struct LevelSM64
 				return MESH_LOADING_DISCARD;
 			}
 			break;
-		case TR::LevelID::LVL_TR1_3B:
+		case TR::LevelID::LVL_TR1_3B: //Tomb of Qualopec
+			switch (meshIndex)
+			{
+
+			}
+			break;
+		case TR::LevelID::LVL_TR1_CUT_1: // cut scene after Larson's fight
 			switch (meshIndex)
 			{
 				
 			}
 			break;
-		case TR::LevelID::LVL_TR1_CUT_1:
-			switch (meshIndex)
-			{
-				
-			}
-			break;
-		case TR::LevelID::LVL_TR1_4:
+		case TR::LevelID::LVL_TR1_4: //St Francis' Folly
 			switch (meshIndex)
 			{
 				

--- a/src/levelsm64.h
+++ b/src/levelsm64.h
@@ -45,7 +45,6 @@ struct LevelSM64
 	{
 		int roomIdx;
 		int faceIdx;
-		//vec3 average;
 		bool positive;
 
 		int32 x[2];
@@ -64,10 +63,10 @@ struct LevelSM64
     struct MarioControllerObj dynamicObjects[4096];
 	int dynamicObjectsCount=0;
 
-	struct FacesToEvaluate xfaces[18192];
+	struct FacesToEvaluate xfaces[4096];
 	int xfacesCount=0;
 
-	struct FacesToEvaluate zfaces[18192];
+	struct FacesToEvaluate zfaces[4096];
 	int zfacesCount=0;
 
 	struct ClipsDetected clips[MAX_CLIPPER_BLOCKS];
@@ -582,7 +581,6 @@ struct LevelSM64
 		}
 	}
 
-
 	void printface(int roomIdx, int faceIdx)
 	{
 		TR::Room &room = level->rooms[roomIdx];
@@ -691,11 +689,6 @@ struct LevelSM64
 		return true;
 
 	}
-
-	float crudeDistance(vec3 v1, vec3 v2)
-	{
-		return abs(v1.x-v2.x)+abs(v1.y-v2.y)+abs(v1.z-v2.z);
-	}
 	
 	void evaluateClippingSurfaces(int *roomsList, int roomsCount)
 	{
@@ -712,6 +705,10 @@ struct LevelSM64
 				}
 			}
 		}
+
+		#ifdef DEBUG_RENDER	
+		printf("%d xfaces to evaluate\n%d zfaces to evaluate\n", xfacesCount, zfacesCount);
+		#endif
 
 		clipsCount = 0;
 		for(int i=0; i<xfacesCount-1; i++)

--- a/src/levelsm64.h
+++ b/src/levelsm64.h
@@ -39,10 +39,48 @@ struct MarioControllerObj
 
 struct LevelSM64
 {
+	/**
+	 * @brief the minimum x,y,z distance between faces of the clipper blocks 
+	 */
+	#define CLIPPER_DISPLACEMENT 40
+
+	enum MESH_LOADING_RESULT{
+		MESH_LOADING_DISCARD,
+		MESH_LOADING_NORMAL,
+		MESH_LOADING_BOUNDING_BOX
+	};
+
+	struct ClipsDetected
+	{
+		int room1;
+		int face1;
+		int room2;
+		int face2;
+	};
+
+	struct FacesToEvaluate
+	{
+		int roomIdx;
+		int faceIdx;
+		vec3 average;
+	};
+
     TR::Level *level=NULL;
 	IController *controller=NULL;
     struct MarioControllerObj dynamicObjects[4096];
 	int dynamicObjectsCount=0;
+
+	struct FacesToEvaluate xfaces[18192];
+	int xfacesCount=0;
+
+	struct FacesToEvaluate zfaces[18192];
+	int zfacesCount=0;
+
+	struct ClipsDetected clips[10];
+	int clipsCount=0;
+
+	SM64Surface clipBlockers[MAX_CLIPPER_BLOCKS_FACES];
+	int clipBlockersCount = 0;
 
     LevelSM64()
     {
@@ -52,18 +90,50 @@ struct LevelSM64
         sm64_level_unload();
     }
 
+	    void loadSM64Level(TR::Level *newLevel, IController *player, int initRoom=0)
+    {
+		level=newLevel;
+		controller = player;
+        #ifdef DEBUG_RENDER	
+        printf("Loading level %d\n", level->id);
+        #endif
+        sm64_level_init(level->roomsCount);
+
+		//createLevelClippers(initRoom);
+
+        for(int roomId=0; roomId< level->roomsCount; roomId++)
+        {
+            int staticSurfacesCount;
+            struct SM64Surface *staticSurfaces = marioLoadRoomSurfaces(roomId, &staticSurfacesCount);
+
+            int roomMeshesCount;
+            struct SM64SurfaceObject *roomMeshes = marioLoadRoomMeshes(roomId, &roomMeshesCount);
+
+            sm64_level_load_room(roomId, staticSurfaces, staticSurfacesCount, roomMeshes, roomMeshesCount);
+
+            free(staticSurfaces);
+            for(int i=0; i<roomMeshesCount; i++)
+            {
+                free(roomMeshes[i].surfaces);
+            }
+            free(roomMeshes);	
+        }
+
+        createDynamicObjects();
+    }
+
     struct SM64Surface* marioLoadRoomSurfaces(int roomId, int *room_surfaces_count)
 	{
 		*room_surfaces_count = 0;
 		size_t level_surface_i = 0;
 
 		TR::Room &room = level->rooms[roomId];
-		TR::Room::Data &d = room.data;
+		TR::Room::Data *d = &room.data;
 
 		// Count the number of static surface triangles
-		for (int j = 0; j < d.fCount; j++)
+		for (int j = 0; j < d->fCount; j++)
 		{
-			TR::Face &f = d.faces[j];
+			TR::Face &f = d->faces[j];
 			if (f.water) continue;
 
 			*room_surfaces_count += (f.triangle) ? 1 : 2;
@@ -72,32 +142,32 @@ struct LevelSM64
 		struct SM64Surface *collision_surfaces = (struct SM64Surface *)malloc(sizeof(struct SM64Surface) * (*room_surfaces_count));
 
 		// Generate all static surface triangles
-		for (int cface = 0; cface < d.fCount; cface++)
+		for (int cface = 0; cface < d->fCount; cface++)
 		{
-			TR::Face &f = d.faces[cface];
+			TR::Face &f = d->faces[cface];
 				if (f.water) continue;
 
-			int16 x[2] = {d.vertices[f.vertices[0]].pos.x, 0};
-			int16 z[2] = {d.vertices[f.vertices[0]].pos.z, 0};
+			int16 x[2] = {d->vertices[f.vertices[0]].pos.x, 0};
+			int16 z[2] = {d->vertices[f.vertices[0]].pos.z, 0};
 			for (int j=1; j<3; j++)
 			{
-				if (x[0] != d.vertices[f.vertices[j]].pos.x) x[1] = d.vertices[f.vertices[j]].pos.x;
-				if (z[0] != d.vertices[f.vertices[j]].pos.z) z[1] = d.vertices[f.vertices[j]].pos.z;
+				if (x[0] != d->vertices[f.vertices[j]].pos.x) x[1] = d->vertices[f.vertices[j]].pos.x;
+				if (z[0] != d->vertices[f.vertices[j]].pos.z) z[1] = d->vertices[f.vertices[j]].pos.z;
 			}
 
 			float midX = (x[0] + x[1]) / 2.f;
-			float topY = max(d.vertices[f.vertices[0]].pos.y, max(d.vertices[f.vertices[1]].pos.y, d.vertices[f.vertices[2]].pos.y));
+			float topY = max(d->vertices[f.vertices[0]].pos.y, max(d->vertices[f.vertices[1]].pos.y, d->vertices[f.vertices[2]].pos.y));
 			float midZ = (z[0] + z[1]) / 2.f;
 
 			TR::Level::FloorInfo info;
 
 			bool slippery = false;
 			if(controller) {
-				controller->getFloorInfo(roomId, vec3(room.info.x + midX, topY, room.info.z + midZ), info);
+				controller->getFloorInfo(roomId, vec3(room.info.x + midX, topY, room.info.z + midZ), info); 
 				slippery = (abs(info.slantX) > 2 || abs(info.slantZ) > 2);
 			}
 
-			ADD_FACE(collision_surfaces, level_surface_i, room, d, f, slippery);
+			ADD_ROOM_FACE_ABSOLUTE(collision_surfaces, level_surface_i, room, d, f, slippery, roomId, cface);
 		}
 
 		return collision_surfaces;
@@ -115,101 +185,196 @@ struct LevelSM64
 		boundingBox->vCount = 8;
 		boundingBox->vertices = (TR::Mesh::Vertex *)malloc(sizeof(TR::Mesh::Vertex)*boundingBox->vCount);
 
-		boundingBox->vertices[0].coord.x=box.min.x;
-		boundingBox->vertices[0].coord.y=box.min.y;
-		boundingBox->vertices[0].coord.z=box.min.z;
-
-		boundingBox->vertices[1].coord.x=box.min.x;
-		boundingBox->vertices[1].coord.y=box.max.y;
-		boundingBox->vertices[1].coord.z=box.min.z;
-
-		boundingBox->vertices[2].coord.x=box.max.x;
-		boundingBox->vertices[2].coord.y=box.max.y;
-		boundingBox->vertices[2].coord.z=box.min.z;
-
-		boundingBox->vertices[3].coord.x=box.max.x;
-		boundingBox->vertices[3].coord.y=box.min.y;
-		boundingBox->vertices[3].coord.z=box.min.z;
-
-		boundingBox->vertices[4].coord.x=box.min.x;
-		boundingBox->vertices[4].coord.y=box.min.y;
-		boundingBox->vertices[4].coord.z=box.max.z;
-
-		boundingBox->vertices[5].coord.x=box.min.x;
-		boundingBox->vertices[5].coord.y=box.max.y;
-		boundingBox->vertices[5].coord.z=box.max.z;
-
-		boundingBox->vertices[6].coord.x=box.max.x;
-		boundingBox->vertices[6].coord.y=box.max.y;
-		boundingBox->vertices[6].coord.z=box.max.z;
-		
-		boundingBox->vertices[7].coord.x=box.max.x;
-		boundingBox->vertices[7].coord.y=box.min.y;
-		boundingBox->vertices[7].coord.z=box.max.z;
-
-		boundingBox->faces[0].triangle=1;
-		boundingBox->faces[0].vertices[0]=2;
-		boundingBox->faces[0].vertices[1]=1;
-		boundingBox->faces[0].vertices[2]=0;
-
-		boundingBox->faces[1].triangle=1;
-		boundingBox->faces[1].vertices[0]=0;
-		boundingBox->faces[1].vertices[1]=3;
-		boundingBox->faces[1].vertices[2]=2;
-
-		boundingBox->faces[2].triangle=1;
-		boundingBox->faces[2].vertices[0]=2;
-		boundingBox->faces[2].vertices[1]=3;
-		boundingBox->faces[2].vertices[2]=7;
-
-		boundingBox->faces[3].triangle=1;
-		boundingBox->faces[3].vertices[0]=7;
-		boundingBox->faces[3].vertices[1]=6;
-		boundingBox->faces[3].vertices[2]=2;
-
-		boundingBox->faces[4].triangle=1;
-		boundingBox->faces[4].vertices[0]=6;
-		boundingBox->faces[4].vertices[1]=7;
-		boundingBox->faces[4].vertices[2]=4;
-
-		boundingBox->faces[5].triangle=1;
-		boundingBox->faces[5].vertices[0]=4;
-		boundingBox->faces[5].vertices[1]=5;
-		boundingBox->faces[5].vertices[2]=6;
-
-		boundingBox->faces[6].triangle=1;
-		boundingBox->faces[6].vertices[0]=4;
-		boundingBox->faces[6].vertices[1]=0;
-		boundingBox->faces[6].vertices[2]=5;
-
-		boundingBox->faces[7].triangle=1;
-		boundingBox->faces[7].vertices[0]=0;
-		boundingBox->faces[7].vertices[1]=1;
-		boundingBox->faces[7].vertices[2]=5;
-
-		boundingBox->faces[8].triangle=1;
-		boundingBox->faces[8].vertices[0]=7;
-		boundingBox->faces[8].vertices[1]=3;
-		boundingBox->faces[8].vertices[2]=0;
-
-		boundingBox->faces[9].triangle=1;
-		boundingBox->faces[9].vertices[0]=0;
-		boundingBox->faces[9].vertices[1]=4;
-		boundingBox->faces[9].vertices[2]=7;
-
-		boundingBox->faces[10].triangle=1;
-		boundingBox->faces[10].vertices[0]=6;
-		boundingBox->faces[10].vertices[1]=5;
-		boundingBox->faces[10].vertices[2]=1;
-
-		boundingBox->faces[11].triangle=1;
-		boundingBox->faces[11].vertices[0]=1;
-		boundingBox->faces[11].vertices[1]=2;
-		boundingBox->faces[11].vertices[2]=6;
+		CREATE_BOUNDING_BOX(boundingBox, box.min.x, box.max.x, box.min.y, box.max.y, box.min.z, box.max.z);
 
 		return boundingBox;
 	}
 
+	TR::Mesh *generateRawMeshBoundingBox(int minx, int maxx, int miny, int maxy, int minz, int maxz)
+	{
+		
+		TR::Mesh *boundingBox = (TR::Mesh *) malloc(sizeof(TR::Mesh));
+		boundingBox->fCount = 12;
+		boundingBox->faces = (TR::Face *)malloc(sizeof(TR::Face)*boundingBox->fCount);
+
+		boundingBox->vCount = 8;
+		boundingBox->vertices = (TR::Mesh::Vertex *)malloc(sizeof(TR::Mesh::Vertex)*boundingBox->vCount);
+
+		CREATE_BOUNDING_BOX(boundingBox, minx, maxx, miny, maxy, minz, maxz);
+
+		return boundingBox;
+	}
+
+	enum MESH_LOADING_RESULT evaluateRoomMeshLoadingOverride(int meshIndex, TR::StaticMesh *sm)
+	{
+		switch(level->id)
+		{
+		case TR::LevelID::LVL_TR1_GYM:
+			switch (meshIndex)
+			{
+				case 0:	// plant - Mario can get stuck
+				case 1:	// plant - Mario can get stuck
+				case 2: // plant - Mario can get stuck
+				case 3: // plant - Mario can get stuck
+					return MESH_LOADING_DISCARD;
+				case 7: //harp - Mario can get stuck
+				case 8: //piano	- Martio can get stuck
+				case 11: //pedestal - Mario can get stuck between it and the columns
+				case 13: //handcart - Mario can get stuck
+					return MESH_LOADING_BOUNDING_BOX;
+				case 9: //table at library is non collision for some reason
+					return MESH_LOADING_NORMAL;
+			}
+			break;
+		case TR::LevelID::LVL_TR1_1: //Caves
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_2: //City of Vilcabamba
+			switch (meshIndex)
+			{
+				case 3: // barn animal food holder - Mario can get stuck on it.
+				case 7:	// Stone Statues - Mario can clip through them and fall into the void.
+					return MESH_LOADING_BOUNDING_BOX;
+				case 6: // platform with small statue - wihtout it mario falls into the void.
+					return MESH_LOADING_NORMAL;
+			}
+			break;
+		case TR::LevelID::LVL_TR1_3A: //The Lost Valley
+			switch (meshIndex)
+			{
+				case 6: // old tree bark - mario gets stuck
+				return MESH_LOADING_DISCARD;
+			}
+			break;
+		case TR::LevelID::LVL_TR1_3B:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_CUT_1:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_4:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_5:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_6:// Palace Midas
+			switch (meshIndex)
+			{
+				case 14: // bushes - mario gets stuck
+				return MESH_LOADING_DISCARD;
+			}
+			break;
+		case TR::LevelID::LVL_TR1_7A:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_7B:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_CUT_2:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_8A:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_8B: //Obelisk of Khamoon
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_8C:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_10A:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_CUT_3:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_10B: //Atlantis
+			switch (meshIndex)
+			{
+				case 0:	// weird flesh 1 surface walls - Mario can clip
+				case 1:	// weird flesh 1 surface walls - Mario can clip
+					return MESH_LOADING_BOUNDING_BOX;
+			}
+			break;
+		case TR::LevelID::LVL_TR1_CUT_4:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_10C:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_EGYPT:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		case TR::LevelID::LVL_TR1_CAT:
+			switch (meshIndex)
+			{
+				
+			}
+			break;
+		}
+
+		if (sm->flags != 2 || !level->meshOffsets[sm->mesh]) 
+		{
+			return MESH_LOADING_DISCARD;
+		}
+
+		// 1 face geometry must use a bounding box or Mario will clip through
+		if( sm->vbox.minX==sm->vbox.maxX || sm->vbox.minY==sm->vbox.maxY || sm->vbox.minZ==sm->vbox.maxZ){
+			return MESH_LOADING_BOUNDING_BOX;
+		}
+
+		return MESH_LOADING_NORMAL;
+	}
+	
 	struct SM64SurfaceObject* marioLoadRoomMeshes(int roomId, int *room_meshes_count)
 	{
 		TR::Room &room = level->rooms[roomId];
@@ -221,146 +386,55 @@ struct LevelSM64
 
 		for (int j = 0; j < room.meshesCount; j++)
 		{
-			TR::Room::Mesh &m  = room.meshes[j];
-			TR::StaticMesh *sm = &(level->staticMeshes[m.meshIndex]);
-			if (sm->flags != 2 || !level->meshOffsets[sm->mesh]) {
-				continue;
+			TR::Room::Mesh *m  = &(room.meshes[j]);
+			TR::StaticMesh *sm = &(level->staticMeshes[m->meshIndex]);
+			
+			enum MESH_LOADING_RESULT action = evaluateRoomMeshLoadingOverride(m->meshIndex, sm);
+
+			TR::Mesh *mesh=NULL;
+
+			switch(action){
+				case MESH_LOADING_DISCARD:
+					continue;
+				case MESH_LOADING_BOUNDING_BOX:
+					mesh = generateMeshBoundingBox(sm);
+					break;
+				case MESH_LOADING_NORMAL:
+				default:
+					mesh = &(level->meshes[level->meshOffsets[sm->mesh]]);
+					break;
 			}
 
 			// define the surface object
 			struct SM64SurfaceObject obj;
 			obj.surfaceCount = 0;
-			obj.transform.position[0] = m.x / MARIO_SCALE;
-			obj.transform.position[1] = -m.y / MARIO_SCALE;
-			obj.transform.position[2] = -m.z / MARIO_SCALE;
-			for (int k=0; k<3; k++) obj.transform.eulerRotation[k] = (k == 1) ? float(m.rotation) / M_PI * 180.f : 0;
-
-			TR::Mesh *d = &(level->meshes[level->meshOffsets[sm->mesh]]);
-			TR::Mesh *boundingBox = NULL;
-
-			switch(level->id)
-			{
-			case TR::LevelID::LVL_TR1_GYM:
-				switch (m.meshIndex)
-				{
-				case 0:	// plant - Mario can get stuck
-				case 1:	// plant - Mario can get stuck
-				case 2: // plant - Mario can get stuck
-				case 3: // plant - Mario can get stuck
-				case 4: // branches - Mario can get stuck
-					continue;
-				case 7: //harp - Mario can get stuck
-				case 8: //piano	- Martio can get stuck
-				case 11: //pedestal - Mario can get stuck between it and the columns
-				case 13: //handcart - Mario can get stuck
-					boundingBox = generateMeshBoundingBox(sm);					
-					break;
-				}
-				break;
-			case TR::LevelID::LVL_TR1_1: //Caves
-				switch (m.meshIndex)
-				{
-				case 0:	// branches - Mario stumbles
-				case 1:	// branches	- Mario stumbles
-				case 7:	// ice stalactite - Mario stumbles
-					continue;
-				// case 2: //wood fence blocking path to exit - solved by viewbox size
-				// 	boundingBox = generateMeshBoundingBox(sm);					
-				// 	break;
-				}
-				break;
-			case TR::LevelID::LVL_TR1_2: //City of Vilcabamba
-				switch (m.meshIndex)
-				{
-				case 0:	// branches - Mario stumbles
-				case 1:	// branches - Mario stumbles
-					continue;
-				case 3: // barn animal food holder - Mario can get stuck on it.
-				case 7:	// Stone Statues - Mario can clip through them and fall into the void.
-					boundingBox = generateMeshBoundingBox(sm);
-					break;
-				}
-				break;
-			case TR::LevelID::LVL_TR1_3A: //The Lost Valley
-				switch (m.meshIndex)
-				{
-				case 0:	// branches - Mario stumbles
-				case 1:	// branches - Mario stumbles
-				case 2: // tree/bushes - Mario can get stuck
-				case 3: // tree/bushes - Mario can get stuck
-				case 4: // tree/bushes - Mario can get stuck
-				case 5: // tree/bushes - Mario can get stuck
-				case 6: // dead tree trunk get mario stuck. we will ignore it.
-				case 7: // trees - Mario can get stuck
-				case 8: // trees - Mario can get stuck
-					continue;
-				case 12: // skeleton - Mario stumbles
-				case 13: // skeleton - Mario stumbles
-					boundingBox = generateMeshBoundingBox(sm);
-					break;
-				}
-				break;
-			case TR::LevelID::LVL_TR1_8B: //Obelisk of Khamoon
-				switch (m.meshIndex)
-				{
-				// case 10: // Iron Bars with only 1 face - solved by viewbox size										
-				// 	boundingBox = generateMeshBoundingBox(sm);
-				// 	break;
-				}
-				break;
-			case TR::LevelID::LVL_TR1_10B: //Atlantis
-				switch (m.meshIndex)
-				{
-				case 0:	// weird flesh 1 surface walls
-				case 1:	// weird flesh 1 surface walls
-					boundingBox = generateMeshBoundingBox(sm);
-					break;
-				}
-				break;
-			}
-			
-			if(boundingBox)
-				d=boundingBox;
-			else if(d->fCount<2 || sm->vbox.minX==sm->vbox.maxX || sm->vbox.minY==sm->vbox.maxY || sm->vbox.minZ==sm->vbox.maxZ){
-				boundingBox = generateMeshBoundingBox(sm);
-				d=boundingBox;
-			}
+			obj.transform.position[0] = m->x / MARIO_SCALE;
+			obj.transform.position[1] = -m->y / MARIO_SCALE;
+			obj.transform.position[2] = -m->z / MARIO_SCALE;
+			for (int k=0; k<3; k++) obj.transform.eulerRotation[k] = (k == 1) ? float(m->rotation) / M_PI * 180.f : 0;
 
 			// increment the surface count for this
-			for (int k = 0; k < d->fCount; k++)
-				obj.surfaceCount += (d->faces[k].triangle) ? 1 : 2;
+			for (int k = 0; k < mesh->fCount; k++)
+				obj.surfaceCount += (mesh->faces[k].triangle) ? 1 : 2;
 
 			obj.surfaces = (SM64Surface*)malloc(sizeof(SM64Surface) * obj.surfaceCount);
 			size_t surface_ind = 0;
 
 			// add the faces
-			for (int k = 0; k < d->fCount; k++)
+			for (int k = 0; k < mesh->fCount; k++)
 			{
-				TR::Face &f = d->faces[k];
-
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
-					{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
-					{(d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE},
-					{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
-				}};
-
-				if (!f.triangle)
-				{
-					obj.surfaces[surface_ind++] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
-						{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
-						{(d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE},
-						{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
-					}};
-				}
+				TR::Face &f = mesh->faces[k];
+				
+				ADD_MESH_FACE_RELATIVE(obj.surfaces, surface_ind, mesh, f);
 			}
 
-			if(boundingBox!=NULL)
+			if( action == MESH_LOADING_BOUNDING_BOX)
 			{
-				free(boundingBox->faces);
-				free(boundingBox->vertices);
-				free(boundingBox);
-				boundingBox=NULL;
+				free(mesh->faces);
+				free(mesh->vertices);
+				free(mesh);
 			}
+			mesh=NULL;
 
 			meshes[(*room_meshes_count)++]=obj;
 		}
@@ -472,33 +546,33 @@ struct LevelSM64
 			if (e->isBlock())
 			{
 				// bottom of block
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
 
 				// left (Z+)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, 128}, {128, 256, 128}, {-128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 256, 128}, {-128, 0, 128}, {128, 0, 128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 0, 128}, {128, 256, 128}, {-128, 256, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 256, 128}, {-128, 0, 128}, {128, 0, 128}}}; // top right, bottom left, bottom right
 
 				// right (Z-)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, -128}, {-128, 256, -128}, {128, 256, -128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 256, -128}, {128, 0, -128}, {-128, 0, -128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 0, -128}, {-128, 256, -128}, {128, 256, -128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 256, -128}, {128, 0, -128}, {-128, 0, -128}}}; // top right, bottom left, bottom right
 
 				// back (X+)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, -128}, {128, 256, -128}, {128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 256, 128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 0, -128}, {128, 256, -128}, {128, 256, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 256, 128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
 
 				// front (X-)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, 128}, {-128, 256, 128}, {-128, 256, -128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 256, -128}, {-128, 0, -128}, {-128, 0, 128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 0, 128}, {-128, 256, 128}, {-128, 256, -128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 256, -128}, {-128, 0, -128}, {-128, 0, 128}}}; // top right, bottom left, bottom right
 
 				// top of block
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 256, 128}, {-128, 256, -128}, {-128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 256, -128}, {128, 256, 128}, {128, 256, -128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 256, 128}, {-128, 256, -128}, {-128, 256, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 256, -128}, {128, 256, 128}, {128, 256, -128}}}; // top right, bottom left, bottom right
 			}
 			else if (e->type == TR::Entity::TRAP_FLOOR)
 			{
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
 			}
 			else
 			{
@@ -507,30 +581,14 @@ struct LevelSM64
 					int index = level->meshOffsets[model->mStart + c];
 					if (index || model->mStart + c <= 0)
 					{
-						TR::Mesh &d = level->meshes[index];
-						for (int j = 0; j < d.fCount; j++)
+						TR::Mesh *d = &(level->meshes[index]);
+						for (int j = 0; j < d->fCount; j++)
 						{
-							TR::Face &f = d.faces[j];
+							TR::Face &f = d->faces[j];
 
-							if (!offset.y) offset.y = topPointSign * max(offset.y, (float)d.vertices[f.vertices[0]].coord.y, max((float)d.vertices[f.vertices[1]].coord.y, (float)d.vertices[f.vertices[2]].coord.y, (f.triangle) ? 0.f : (float)d.vertices[f.vertices[3]].coord.y));
+							if (!offset.y) offset.y = topPointSign * max(offset.y, (float)d->vertices[f.vertices[0]].coord.y, max((float)d->vertices[f.vertices[1]].coord.y, (float)d->vertices[f.vertices[2]].coord.y, (f.triangle) ? 0.f : (float)d->vertices[f.vertices[3]].coord.y));
 
-							obj.surfaces[surface_ind] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
-								{(d.vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
-								{(d.vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[1]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[1]].coord.z)/IMARIO_SCALE},
-								{(d.vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
-							}};
-
-							if (!f.triangle)
-							{
-								surface_ind++;
-								obj.surfaces[surface_ind] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
-									{(d.vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
-									{(d.vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[3]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[3]].coord.z)/IMARIO_SCALE},
-									{(d.vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
-								}};
-							}
-
-							surface_ind++;
+							ADD_MESH_FACE_RELATIVE(obj.surfaces, surface_ind, d, f);
 						}
 					}
 				}
@@ -552,40 +610,220 @@ struct LevelSM64
 		}
 	}
 
-    
+    void getFaceMiddlePoint(int roomIdx, int faceIdx, struct FacesToEvaluate *face)
+	{
+		TR::Room &room = level->rooms[roomIdx];
+		TR::Room::Data &d = room.data;
+		TR::Face &f = d.faces[faceIdx];
 
-    void loadSM64Level(TR::Level *newLevel, IController *player)
-    {
-		level=newLevel;
-		controller = player;
-        #ifdef DEBUG_RENDER	
-        printf("Loading level %d\n", level->id);
-        #endif
-        sm64_level_init(level->roomsCount);
+		face->roomIdx = roomIdx;
+		face->faceIdx = faceIdx;
+		face->average = vec3(
+			(d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+d.vertices[f.vertices[3]].pos.x+(4*room.info.x))/4.0f,
+			(d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y+d.vertices[f.vertices[3]].pos.y)/4.0f,
+			(d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+d.vertices[f.vertices[3]].pos.z+(4*room.info.z))/4.0f
+		);
+	}
 
-        for(int roomId=0; roomId< level->roomsCount; roomId++)
-        {
-            int staticSurfacesCount;
-            struct SM64Surface *staticSurfaces = marioLoadRoomSurfaces(roomId, &staticSurfacesCount);
+	bool evalXface(int roomIdx, int faceIdx)
+	{
+		TR::Room &room = level->rooms[roomIdx];
+		TR::Room::Data &d = room.data;
+		TR::Face &f = d.faces[faceIdx];
 
-            int roomMeshesCount;
-            struct SM64SurfaceObject *roomMeshes = marioLoadRoomMeshes(roomId, &roomMeshesCount);
+		if(f.water || f.triangle)
+		{
+			return false;	
+		}
 
-            sm64_level_load_room(roomId, staticSurfaces, staticSurfacesCount, roomMeshes, roomMeshesCount);
+		int16 x = d.vertices[f.vertices[0]].pos.x;
+		if(d.vertices[f.vertices[1]].pos.x == x && d.vertices[f.vertices[2]].pos.x == x && d.vertices[f.vertices[3]].pos.x==x)
+		{
+			getFaceMiddlePoint(roomIdx, faceIdx, &(xfaces[xfacesCount++]));
+			return true;
+		}
+		return false;
+	}
 
-            free(staticSurfaces);
-            for(int i=0; i<roomMeshesCount; i++)
-            {
-                free(roomMeshes[i].surfaces);
-            }
-            free(roomMeshes);	
-        }
+	void printface(int roomIdx, int faceIdx)
+	{
+		TR::Room &room = level->rooms[roomIdx];
+		TR::Room::Data &d = room.data;
+		TR::Face &f = d.faces[faceIdx];
 
-        createDynamicObjects();
-    }
+		if(f.water || f.triangle)
+		{
+			return;
+		}
+
+		printf("face r:%d i:%d\n", roomIdx, faceIdx);
+		printf("(%d, %d, %d)\n", d.vertices[f.vertices[0]].pos.x+room.info.x, d.vertices[f.vertices[0]].pos.y, d.vertices[f.vertices[0]].pos.z+room.info.z);
+		printf("(%d, %d, %d)\n", d.vertices[f.vertices[1]].pos.x+room.info.x, d.vertices[f.vertices[1]].pos.y, d.vertices[f.vertices[1]].pos.z+room.info.z);
+		printf("(%d, %d, %d)\n", d.vertices[f.vertices[2]].pos.x+room.info.x, d.vertices[f.vertices[2]].pos.y, d.vertices[f.vertices[2]].pos.z+room.info.z);
+		printf("(%d, %d, %d)\n", d.vertices[f.vertices[3]].pos.x+room.info.x, d.vertices[f.vertices[3]].pos.y, d.vertices[f.vertices[3]].pos.z+room.info.z);
+	}
+
+	bool evalZface(int roomIdx, int faceIdx)
+	{
+		TR::Room &room = level->rooms[roomIdx];
+		TR::Room::Data &d = room.data;
+		TR::Face &f = d.faces[faceIdx];
+
+		if(f.water || f.triangle)
+		{
+			return false;	
+		}
+
+		int16 z = d.vertices[f.vertices[0]].pos.z;
+		if(d.vertices[f.vertices[1]].pos.z == z && d.vertices[f.vertices[2]].pos.z == z && d.vertices[f.vertices[3]].pos.z==z)
+		{
+			getFaceMiddlePoint(roomIdx, faceIdx, &(zfaces[zfacesCount++]));
+			return true;
+		}
+		return false;
+	}
+
+	float crudeDistance(vec3 v1, vec3 v2)
+	{
+		return abs(v1.x-v2.x)+abs(v1.y-v2.y)+abs(v1.z-v2.z);
+	}
+
+	void evaluateClippingSurfaces(int *roomsList, int roomsCount)
+	{
+		xfacesCount=0;
+		zfacesCount=0;
+		for(int roomId=0; roomId<roomsCount; roomId++)
+		{
+			for(int faceId=0; faceId<level->rooms[roomsList[roomId]].data.fCount; faceId++)
+			{
+				if(!evalXface(roomsList[roomId], faceId))
+				{
+					evalZface(roomsList[roomId], faceId);
+				}
+			}
+		}
+
+		//printf("xfaces: %d\tzfaces: %d\n", xfacesCount, zfacesCount);
+
+		//printf("Evaluating clips...\n");
+		clipsCount = 0;
+		for(int i=0; i<xfacesCount-1; i++)
+		{
+			for(int j=i+1; j<xfacesCount; j++)
+			{
+				if(crudeDistance(xfaces[i].average, xfaces[j].average)<50)
+				{
+					clips[clipsCount].room1=xfaces[i].roomIdx;
+					clips[clipsCount].face1=xfaces[i].faceIdx;
+					clips[clipsCount].room2=xfaces[j].roomIdx;
+					clips[clipsCount].face2=xfaces[j].faceIdx;
+					clipsCount++;
+					//printf("found xclip between room %d face %d with room %d with face %d with crude distance of %f\n", xfaces[i].roomIdx, xfaces[i].faceIdx, xfaces[j].roomIdx, xfaces[j].faceIdx, crudeDistance(xfaces[i].average, xfaces[j].average));
+					//printface(xfaces[i].roomIdx, xfaces[i].faceIdx);
+				}
+			}
+		}
+		for(int i=0; i<zfacesCount-1; i++)
+		{
+			for(int j=i+1; j<zfacesCount; j++)
+			{
+				if(crudeDistance(zfaces[i].average, zfaces[j].average)<50)
+				{
+					clips[clipsCount].room1=zfaces[i].roomIdx;
+					clips[clipsCount].face1=zfaces[i].faceIdx;
+					clips[clipsCount].room2=zfaces[j].roomIdx;
+					clips[clipsCount].face2=zfaces[j].faceIdx;
+					clipsCount++;
+					//printf("found zclip between room %d face %d with room %d with face %d with crude distance of %f\n", zfaces[i].roomIdx, zfaces[i].faceIdx, zfaces[j].roomIdx, zfaces[j].faceIdx, crudeDistance(zfaces[i].average, zfaces[j].average));
+					//printface(zfaces[i].roomIdx, zfaces[i].faceIdx);
+				}
+			}
+		}
+	}
+
+	void createClipBlockers()
+	{
+		clipBlockersCount=0;
+
+		for(int i=0; i<clipsCount; i++)
+		{
+			TR::Room &room = level->rooms[clips[i].room1];
+			TR::Room::Data &d = room.data;
+			TR::Face &f = d.faces[clips[i].face1];
+
+			//printface(clips[i].room1, clips[i].face1);
+
+			int minx = d.vertices[f.vertices[0]].pos.x;
+			int maxx = d.vertices[f.vertices[0]].pos.x;
+			for(int i=1; i<4; i++){
+				if(d.vertices[f.vertices[i]].pos.x > maxx) maxx = d.vertices[f.vertices[i]].pos.x;
+				if(d.vertices[f.vertices[i]].pos.x < minx) minx = d.vertices[f.vertices[i]].pos.x;				
+			}
+			if(minx == maxx)
+			{
+				minx-=CLIPPER_DISPLACEMENT;
+				maxx+=CLIPPER_DISPLACEMENT;
+			}
+
+			int miny = d.vertices[f.vertices[0]].pos.y;
+			int maxy = d.vertices[f.vertices[0]].pos.y;
+			for(int i=1; i<4; i++){
+				if(d.vertices[f.vertices[i]].pos.y > maxy) maxy = d.vertices[f.vertices[i]].pos.y;
+				if(d.vertices[f.vertices[i]].pos.y < miny) miny = d.vertices[f.vertices[i]].pos.y;
+			}
+			if(miny == maxy)
+			{
+				miny-=CLIPPER_DISPLACEMENT;
+				maxy+=CLIPPER_DISPLACEMENT;
+			}
+
+			int minz = d.vertices[f.vertices[0]].pos.z;
+			int maxz = d.vertices[f.vertices[0]].pos.z;
+			for(int i=1; i<4; i++){
+				if(d.vertices[f.vertices[i]].pos.z > maxz) maxz = d.vertices[f.vertices[i]].pos.z;
+				if(d.vertices[f.vertices[i]].pos.z < minz) minz = d.vertices[f.vertices[i]].pos.z;				
+			}
+			if(minz == maxz)
+			{
+				minz-=CLIPPER_DISPLACEMENT;
+				maxz+=CLIPPER_DISPLACEMENT;
+			}
+
+			TR::Mesh *mesh = generateRawMeshBoundingBox(minx, maxx, miny, maxy, minz, maxz);
+
+			for(int i=0; i<mesh->fCount; i++)
+			{		
+				ADD_MESH_FACE_ABSOLUTE(clipBlockers,clipBlockersCount, room, mesh, mesh->faces[i] );
+			}
+			
+			free(mesh->faces);
+			free(mesh);
+		}
+	}
+
+	void getCurrentAndAdjacentRoomsWithClips(int marioId, int currentRoomIndex, int to, int maxDepth, bool evaluateClips = false) 
+	{
+		int nearRooms[256];
+		int nearRoomsCount=0;
+
+		getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, currentRoomIndex, to, 2);
+
+		if(evaluateClips)
+		{
+			evaluateClippingSurfaces(nearRooms, nearRoomsCount);
+			createClipBlockers();
+			sm64_level_update_player_loaded_Rooms_with_clippers(marioId, nearRooms, nearRoomsCount, clipBlockers, clipBlockersCount);
+		}
+		else
+		{
+			sm64_level_update_loaded_rooms_list(marioId, nearRooms, nearRoomsCount);
+		}
+
+		return;			
+	}
 
 	void getCurrentAndAdjacentRooms(int *roomsList, int *roomsCount, int currentRoomIndex, int to, int maxDepth, int count=0) {
-        if (count>maxDepth) {
+        if (count>maxDepth || *roomsCount == 256) {
             return;
         }
 
@@ -607,6 +845,7 @@ struct LevelSM64
 					return;
 			}
 		}
+		
 
 		count++;
 
@@ -618,13 +857,18 @@ struct LevelSM64
 			*roomsCount+=1;
 		}
 
-		if(*roomsCount == 256)
-			return;
-
 		for (int i = 0; i < room.portalsCount; i++) {
 			getCurrentAndAdjacentRooms(roomsList, roomsCount, currentRoomIndex, room.portals[i].roomIndex, maxDepth, count);
 		}
     }
+
+	int createMarioInstance(int roomIndex, vec3(pos))
+	{
+		int nearRooms[256];
+		int nearRoomsCount=0;
+		getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, roomIndex, roomIndex, 2);
+		return sm64_mario_create(pos.x/MARIO_SCALE, -pos.y/MARIO_SCALE, -pos.z/MARIO_SCALE, 0, 0, 0, 0, nearRooms, nearRoomsCount);
+	}
 
 
 };

--- a/src/levelsm64.h
+++ b/src/levelsm64.h
@@ -103,7 +103,7 @@ struct LevelSM64
 		return collision_surfaces;
 	}
 
-    	TR::Mesh *generateMeshBoundingBox(TR::StaticMesh *sm)
+	TR::Mesh *generateMeshBoundingBox(TR::StaticMesh *sm)
 	{
 		Box box;
 		sm->getBox(true, box);
@@ -582,6 +582,48 @@ struct LevelSM64
         }
 
         createDynamicObjects();
+    }
+
+	void getCurrentAndAdjacentRooms(int *roomsList, int *roomsCount, int currentRoomIndex, int to, int maxDepth, int count=0) {
+        if (count>maxDepth) {
+            return;
+        }
+
+		// if we are starting to search we set all levels visibility to false
+		if(count==0)
+		{
+			for (int i = 0; i < level->roomsCount; i++)
+				level->rooms[i].flags.visible = false;
+		}
+
+		//Hardcoded exceptions to avoid invisible collisions
+		switch (level->id)
+		{
+		case TR::LVL_TR1_10B: //Atlantis
+			switch (currentRoomIndex)
+			{
+			case 47: //room with blocks and switches to trapdoors
+				if(to==84)
+					return;
+			}
+		}
+
+		count++;
+
+        TR::Room &room = level->rooms[to];
+
+		if(!room.flags.visible){
+			room.flags.visible = true;
+			roomsList[*roomsCount] = to;
+			*roomsCount+=1;
+		}
+
+		if(*roomsCount == 256)
+			return;
+
+		for (int i = 0; i < room.portalsCount; i++) {
+			getCurrentAndAdjacentRooms(roomsList, roomsCount, currentRoomIndex, room.portals[i].roomIndex, maxDepth, count);
+		}
     }
 
 

--- a/src/levelsm64.h
+++ b/src/levelsm64.h
@@ -57,11 +57,9 @@ struct LevelSM64
 		//vec3 average;
 		bool positive;
 
-		float x[2];
-		float y[2];
-		float z[2];
-
-		
+		int32 x[2];
+		int32 y[2];
+		int32 z[2];
 	};
 
 	struct ClipsDetected
@@ -95,7 +93,7 @@ struct LevelSM64
         sm64_level_unload();
     }
 
-	    void loadSM64Level(TR::Level *newLevel, IController *player, int initRoom=0)
+	void loadSM64Level(TR::Level *newLevel, IController *player, int initRoom=0)
     {
 		level=newLevel;
 		controller = player;
@@ -170,7 +168,7 @@ struct LevelSM64
 				slippery = (abs(info.slantX) > 2 || abs(info.slantZ) > 2);
 			}
 
-			ADD_ROOM_FACE_ABSOLUTE(collision_surfaces, level_surface_i, room, d, f, slippery, roomId, cface);
+			ADD_ROOM_FACE_ABSOLUTE(collision_surfaces, level_surface_i, room, d, f, slippery);
 		}
 
 		return collision_surfaces;
@@ -550,33 +548,33 @@ struct LevelSM64
 			if (e->isBlock())
 			{
 				// bottom of block
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
 
 				// left (Z+)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 0, 128}, {128, 256, 128}, {-128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 256, 128}, {-128, 0, 128}, {128, 0, 128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 0, 128}, {128, 256, 128}, {-128, 256, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 256, 128}, {-128, 0, 128}, {128, 0, 128}}}; // top right, bottom left, bottom right
 
 				// right (Z-)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 0, -128}, {-128, 256, -128}, {128, 256, -128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 256, -128}, {128, 0, -128}, {-128, 0, -128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 0, -128}, {-128, 256, -128}, {128, 256, -128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 256, -128}, {128, 0, -128}, {-128, 0, -128}}}; // top right, bottom left, bottom right
 
 				// back (X+)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 0, -128}, {128, 256, -128}, {128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 256, 128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 0, -128}, {128, 256, -128}, {128, 256, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 256, 128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
 
 				// front (X-)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 0, 128}, {-128, 256, 128}, {-128, 256, -128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 256, -128}, {-128, 0, -128}, {-128, 0, 128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 0, 128}, {-128, 256, 128}, {-128, 256, -128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 256, -128}, {-128, 0, -128}, {-128, 0, 128}}}; // top right, bottom left, bottom right
 
 				// top of block
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 256, 128}, {-128, 256, -128}, {-128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 256, -128}, {128, 256, 128}, {128, 256, -128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 256, 128}, {-128, 256, -128}, {-128, 256, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 256, -128}, {128, 256, 128}, {128, 256, -128}}}; // top right, bottom left, bottom right
 			}
 			else if (e->type == TR::Entity::TRAP_FLOOR)
 			{
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, -1, -1, {{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
 			}
 			else
 			{
@@ -651,12 +649,12 @@ struct LevelSM64
 			return false;	
 		}
 
-		float x = d.vertices[f.vertices[0]].pos.x+room.info.x;
+		int32 x = d.vertices[f.vertices[0]].pos.x+room.info.x;
 
-		float miny = d.vertices[f.vertices[0]].pos.y;
-		float maxy = d.vertices[f.vertices[0]].pos.y;
-		float minz = d.vertices[f.vertices[0]].pos.z;
-		float maxz = d.vertices[f.vertices[0]].pos.z;
+		int32 miny = d.vertices[f.vertices[0]].pos.y;
+		int32 maxy = d.vertices[f.vertices[0]].pos.y;
+		int32 minz = d.vertices[f.vertices[0]].pos.z;
+		int32 maxz = d.vertices[f.vertices[0]].pos.z;
 
 		for(int i=1; i<4; i++)
 		{
@@ -696,12 +694,12 @@ struct LevelSM64
 			return false;	
 		}
 
-		float z = d.vertices[f.vertices[0]].pos.z+room.info.z;
+		int32 z = d.vertices[f.vertices[0]].pos.z+room.info.z;
 
-		float miny = d.vertices[f.vertices[0]].pos.y;
-		float maxy = d.vertices[f.vertices[0]].pos.y;
-		float minx = d.vertices[f.vertices[0]].pos.x;
-		float maxx = d.vertices[f.vertices[0]].pos.x;
+		int32 miny = d.vertices[f.vertices[0]].pos.y;
+		int32 maxy = d.vertices[f.vertices[0]].pos.y;
+		int32 minx = d.vertices[f.vertices[0]].pos.x;
+		int32 maxx = d.vertices[f.vertices[0]].pos.x;
 
 		for(int i=1; i<4; i++)
 		{
@@ -806,94 +804,20 @@ struct LevelSM64
 		for(int i=0; i<clipsCount; i++)
 		{
 			FacesToEvaluate *e = clips[i].face1;
-			TR::Room &room = level->rooms[e->roomIdx];
-			TR::Room::Data &d = room.data;
-			TR::Face &f = d.faces[e->faceIdx];
 
-			int minx = d.vertices[f.vertices[0]].pos.x;
-			int maxx = d.vertices[f.vertices[0]].pos.x;
-			for(int i=1; i<4; i++){
-				if(d.vertices[f.vertices[i]].pos.x > maxx) maxx = d.vertices[f.vertices[i]].pos.x;
-				if(d.vertices[f.vertices[i]].pos.x < minx) minx = d.vertices[f.vertices[i]].pos.x;				
-			}
-			if(minx == maxx)
+			if(e->x[0] == e->x[1])
 			{
-				minx-=CLIPPER_DISPLACEMENT;
-				maxx+=CLIPPER_DISPLACEMENT;
+				e->x[0]-=CLIPPER_DISPLACEMENT;
+				e->x[1]+=CLIPPER_DISPLACEMENT;
 			}
 
-			int miny = d.vertices[f.vertices[0]].pos.y;
-			int maxy = d.vertices[f.vertices[0]].pos.y;
-			for(int i=1; i<4; i++){
-				if(d.vertices[f.vertices[i]].pos.y > maxy) maxy = d.vertices[f.vertices[i]].pos.y;
-				if(d.vertices[f.vertices[i]].pos.y < miny) miny = d.vertices[f.vertices[i]].pos.y;
-			}
-			if(miny == maxy)
+			if(e->z[0] == e->z[1])
 			{
-				miny-=CLIPPER_DISPLACEMENT;
-				maxy+=CLIPPER_DISPLACEMENT;
+				e->z[0]-=CLIPPER_DISPLACEMENT;
+				e->z[1]+=CLIPPER_DISPLACEMENT;
 			}
 
-			int minz = d.vertices[f.vertices[0]].pos.z;
-			int maxz = d.vertices[f.vertices[0]].pos.z;
-			for(int i=1; i<4; i++){
-				if(d.vertices[f.vertices[i]].pos.z > maxz) maxz = d.vertices[f.vertices[i]].pos.z;
-				if(d.vertices[f.vertices[i]].pos.z < minz) minz = d.vertices[f.vertices[i]].pos.z;				
-			}
-			if(minz == maxz)
-			{
-				minz-=CLIPPER_DISPLACEMENT;
-				maxz+=CLIPPER_DISPLACEMENT;
-			}
-
-			// if(e->x[0] == e->x[1])
-			// {
-			// 	e->x[0]-=CLIPPER_DISPLACEMENT;
-			// 	e->x[1]+=CLIPPER_DISPLACEMENT;
-			// }
-
-			// if(e->z[0] == e->z[1])
-			// {
-			// 	e->z[0]-=CLIPPER_DISPLACEMENT;
-			// 	e->z[1]+=CLIPPER_DISPLACEMENT;
-			// }
-
-			TR::Mesh *mesh = generateRawMeshBoundingBox(minx, maxx, miny, maxy, minz, maxz);
-
-			for(int i=0; i<mesh->fCount; i++)
-			{		
-				ADD_MESH_FACE_ABSOLUTE(clipBlockers,clipBlockersCount, room, mesh, mesh->faces[i] );
-			}
-			
-			free(mesh->faces);
-			free(mesh);
-
-			// FacesToEvaluate *e = clips[i].face1;
-			// TR::Room &room = level->rooms[e->roomIdx];
-			// TR::Room::Data &d = room.data;
-			// TR::Face &f = d.faces[e->faceIdx];
-
-			// if(e->x[0] == e->x[1])
-			// {
-			// 	e->x[0]-=CLIPPER_DISPLACEMENT;
-			// 	e->x[1]+=CLIPPER_DISPLACEMENT;
-			// }
-
-			// if(e->z[0] == e->z[1])
-			// {
-			// 	e->z[0]-=CLIPPER_DISPLACEMENT;
-			// 	e->z[1]+=CLIPPER_DISPLACEMENT;
-			// }
-
-			// TR::Mesh *mesh = generateRawMeshBoundingBox(e->x[0], e->x[1], e->y[0], e->y[1], e->z[0], e->z[1]);
-
-			// for(int i=0; i<mesh->fCount; i++)
-			// {		
-			// 	ADD_MESH_FACE_RELATIVE_SCALED(clipBlockers,clipBlockersCount, mesh, mesh->faces[i] );
-			// }
-			
-			// free(mesh->faces);
-			// free(mesh);
+			ADD_CUBE_GEOMETRY(clipBlockers, clipBlockersCount, 0, 0, e->x[0], e->x[1], e->y[0], e->y[1], e->z[0], e->z[1]);
 		}
 	}
 
@@ -902,7 +826,7 @@ struct LevelSM64
 		int nearRooms[256];
 		int nearRoomsCount=0;
 
-		getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, currentRoomIndex, to, 2);
+		getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, currentRoomIndex, to, maxDepth);
 
 		if(evaluateClips)
 		{

--- a/src/levelsm64.h
+++ b/src/levelsm64.h
@@ -1,0 +1,590 @@
+#ifndef H_LEVELSM64
+#define H_LEVELSM64
+
+extern "C" {
+	#include <libsm64/src/libsm64.h>
+	#include <libsm64/src/decomp/include/external_types.h>
+	#include <libsm64/src/decomp/include/surface_terrains.h>
+	#include <libsm64/src/decomp/include/PR/ultratypes.h>
+	#include <libsm64/src/decomp/include/audio_defines.h>
+	#include <libsm64/src/decomp/include/seq_ids.h>
+	#include <libsm64/src/decomp/include/mario_animation_ids.h>
+}
+
+
+#include "core.h"
+// #include "game.h"
+// #include "lara.h"
+// #include "objects.h"
+// #include "sprite.h"
+// #include "enemy.h"
+// #include "inventory.h"
+// #include "mesh.h"
+#include "format.h"
+// #include "level.h"
+#include "controller.h"
+
+#include "marioMacros.h"
+
+struct MarioControllerObj
+{
+	MarioControllerObj() : ID(0), entity(NULL), spawned(false) {}
+
+	uint32_t ID;
+	struct SM64ObjectTransform transform;
+	TR::Entity* entity;
+	vec3 offset;
+	bool spawned;
+};
+
+struct LevelSM64
+{
+    TR::Level *level=NULL;
+	IController *controller=NULL;
+    struct MarioControllerObj dynamicObjects[4096];
+	int dynamicObjectsCount=0;
+
+    LevelSM64()
+    {
+    }
+    ~LevelSM64()
+    {
+        sm64_level_unload();
+    }
+
+    struct SM64Surface* marioLoadRoomSurfaces(int roomId, int *room_surfaces_count)
+	{
+		*room_surfaces_count = 0;
+		size_t level_surface_i = 0;
+
+		TR::Room &room = level->rooms[roomId];
+		TR::Room::Data &d = room.data;
+
+		// Count the number of static surface triangles
+		for (int j = 0; j < d.fCount; j++)
+		{
+			TR::Face &f = d.faces[j];
+			if (f.water) continue;
+
+			*room_surfaces_count += (f.triangle) ? 1 : 2;
+		}
+
+		struct SM64Surface *collision_surfaces = (struct SM64Surface *)malloc(sizeof(struct SM64Surface) * (*room_surfaces_count));
+
+		// Generate all static surface triangles
+		for (int cface = 0; cface < d.fCount; cface++)
+		{
+			TR::Face &f = d.faces[cface];
+				if (f.water) continue;
+
+			int16 x[2] = {d.vertices[f.vertices[0]].pos.x, 0};
+			int16 z[2] = {d.vertices[f.vertices[0]].pos.z, 0};
+			for (int j=1; j<3; j++)
+			{
+				if (x[0] != d.vertices[f.vertices[j]].pos.x) x[1] = d.vertices[f.vertices[j]].pos.x;
+				if (z[0] != d.vertices[f.vertices[j]].pos.z) z[1] = d.vertices[f.vertices[j]].pos.z;
+			}
+
+			float midX = (x[0] + x[1]) / 2.f;
+			float topY = max(d.vertices[f.vertices[0]].pos.y, max(d.vertices[f.vertices[1]].pos.y, d.vertices[f.vertices[2]].pos.y));
+			float midZ = (z[0] + z[1]) / 2.f;
+
+			TR::Level::FloorInfo info;
+
+			bool slippery = false;
+			if(controller) {
+				controller->getFloorInfo(roomId, vec3(room.info.x + midX, topY, room.info.z + midZ), info);
+				slippery = (abs(info.slantX) > 2 || abs(info.slantZ) > 2);
+			}
+
+			ADD_FACE(collision_surfaces, level_surface_i, room, d, f, slippery);
+		}
+
+		return collision_surfaces;
+	}
+
+    	TR::Mesh *generateMeshBoundingBox(TR::StaticMesh *sm)
+	{
+		Box box;
+		sm->getBox(true, box);
+		
+		TR::Mesh *boundingBox = (TR::Mesh *) malloc(sizeof(TR::Mesh));
+		boundingBox->fCount = 12;
+		boundingBox->faces = (TR::Face *)malloc(sizeof(TR::Face)*boundingBox->fCount);
+
+		boundingBox->vCount = 8;
+		boundingBox->vertices = (TR::Mesh::Vertex *)malloc(sizeof(TR::Mesh::Vertex)*boundingBox->vCount);
+
+		boundingBox->vertices[0].coord.x=box.min.x;
+		boundingBox->vertices[0].coord.y=box.min.y;
+		boundingBox->vertices[0].coord.z=box.min.z;
+
+		boundingBox->vertices[1].coord.x=box.min.x;
+		boundingBox->vertices[1].coord.y=box.max.y;
+		boundingBox->vertices[1].coord.z=box.min.z;
+
+		boundingBox->vertices[2].coord.x=box.max.x;
+		boundingBox->vertices[2].coord.y=box.max.y;
+		boundingBox->vertices[2].coord.z=box.min.z;
+
+		boundingBox->vertices[3].coord.x=box.max.x;
+		boundingBox->vertices[3].coord.y=box.min.y;
+		boundingBox->vertices[3].coord.z=box.min.z;
+
+		boundingBox->vertices[4].coord.x=box.min.x;
+		boundingBox->vertices[4].coord.y=box.min.y;
+		boundingBox->vertices[4].coord.z=box.max.z;
+
+		boundingBox->vertices[5].coord.x=box.min.x;
+		boundingBox->vertices[5].coord.y=box.max.y;
+		boundingBox->vertices[5].coord.z=box.max.z;
+
+		boundingBox->vertices[6].coord.x=box.max.x;
+		boundingBox->vertices[6].coord.y=box.max.y;
+		boundingBox->vertices[6].coord.z=box.max.z;
+		
+		boundingBox->vertices[7].coord.x=box.max.x;
+		boundingBox->vertices[7].coord.y=box.min.y;
+		boundingBox->vertices[7].coord.z=box.max.z;
+
+		boundingBox->faces[0].triangle=1;
+		boundingBox->faces[0].vertices[0]=2;
+		boundingBox->faces[0].vertices[1]=1;
+		boundingBox->faces[0].vertices[2]=0;
+
+		boundingBox->faces[1].triangle=1;
+		boundingBox->faces[1].vertices[0]=0;
+		boundingBox->faces[1].vertices[1]=3;
+		boundingBox->faces[1].vertices[2]=2;
+
+		boundingBox->faces[2].triangle=1;
+		boundingBox->faces[2].vertices[0]=2;
+		boundingBox->faces[2].vertices[1]=3;
+		boundingBox->faces[2].vertices[2]=7;
+
+		boundingBox->faces[3].triangle=1;
+		boundingBox->faces[3].vertices[0]=7;
+		boundingBox->faces[3].vertices[1]=6;
+		boundingBox->faces[3].vertices[2]=2;
+
+		boundingBox->faces[4].triangle=1;
+		boundingBox->faces[4].vertices[0]=6;
+		boundingBox->faces[4].vertices[1]=7;
+		boundingBox->faces[4].vertices[2]=4;
+
+		boundingBox->faces[5].triangle=1;
+		boundingBox->faces[5].vertices[0]=4;
+		boundingBox->faces[5].vertices[1]=5;
+		boundingBox->faces[5].vertices[2]=6;
+
+		boundingBox->faces[6].triangle=1;
+		boundingBox->faces[6].vertices[0]=4;
+		boundingBox->faces[6].vertices[1]=0;
+		boundingBox->faces[6].vertices[2]=5;
+
+		boundingBox->faces[7].triangle=1;
+		boundingBox->faces[7].vertices[0]=0;
+		boundingBox->faces[7].vertices[1]=1;
+		boundingBox->faces[7].vertices[2]=5;
+
+		boundingBox->faces[8].triangle=1;
+		boundingBox->faces[8].vertices[0]=7;
+		boundingBox->faces[8].vertices[1]=3;
+		boundingBox->faces[8].vertices[2]=0;
+
+		boundingBox->faces[9].triangle=1;
+		boundingBox->faces[9].vertices[0]=0;
+		boundingBox->faces[9].vertices[1]=4;
+		boundingBox->faces[9].vertices[2]=7;
+
+		boundingBox->faces[10].triangle=1;
+		boundingBox->faces[10].vertices[0]=6;
+		boundingBox->faces[10].vertices[1]=5;
+		boundingBox->faces[10].vertices[2]=1;
+
+		boundingBox->faces[11].triangle=1;
+		boundingBox->faces[11].vertices[0]=1;
+		boundingBox->faces[11].vertices[1]=2;
+		boundingBox->faces[11].vertices[2]=6;
+
+		return boundingBox;
+	}
+
+	struct SM64SurfaceObject* marioLoadRoomMeshes(int roomId, int *room_meshes_count)
+	{
+		TR::Room &room = level->rooms[roomId];
+		TR::Room::Data &d = room.data;
+
+		*room_meshes_count = 0;
+
+		struct SM64SurfaceObject *meshes = (struct SM64SurfaceObject*)malloc(sizeof(struct SM64SurfaceObject)*room.meshesCount);
+
+		for (int j = 0; j < room.meshesCount; j++)
+		{
+			TR::Room::Mesh &m  = room.meshes[j];
+			TR::StaticMesh *sm = &(level->staticMeshes[m.meshIndex]);
+			if (sm->flags != 2 || !level->meshOffsets[sm->mesh]) {
+				continue;
+			}
+
+			// define the surface object
+			struct SM64SurfaceObject obj;
+			obj.surfaceCount = 0;
+			obj.transform.position[0] = m.x / MARIO_SCALE;
+			obj.transform.position[1] = -m.y / MARIO_SCALE;
+			obj.transform.position[2] = -m.z / MARIO_SCALE;
+			for (int k=0; k<3; k++) obj.transform.eulerRotation[k] = (k == 1) ? float(m.rotation) / M_PI * 180.f : 0;
+
+			TR::Mesh *d = &(level->meshes[level->meshOffsets[sm->mesh]]);
+			TR::Mesh *boundingBox = NULL;
+
+			switch(level->id)
+			{
+			case TR::LevelID::LVL_TR1_GYM:
+				switch (m.meshIndex)
+				{
+				case 0:	// plant - Mario can get stuck
+				case 1:	// plant - Mario can get stuck
+				case 2: // plant - Mario can get stuck
+				case 3: // plant - Mario can get stuck
+				case 4: // branches - Mario can get stuck
+					continue;
+				case 7: //harp - Mario can get stuck
+				case 8: //piano	- Martio can get stuck
+				case 11: //pedestal - Mario can get stuck between it and the columns
+				case 13: //handcart - Mario can get stuck
+					boundingBox = generateMeshBoundingBox(sm);					
+					break;
+				}
+				break;
+			case TR::LevelID::LVL_TR1_1: //Caves
+				switch (m.meshIndex)
+				{
+				case 0:	// branches - Mario stumbles
+				case 1:	// branches	- Mario stumbles
+				case 7:	// ice stalactite - Mario stumbles
+					continue;
+				// case 2: //wood fence blocking path to exit - solved by viewbox size
+				// 	boundingBox = generateMeshBoundingBox(sm);					
+				// 	break;
+				}
+				break;
+			case TR::LevelID::LVL_TR1_2: //City of Vilcabamba
+				switch (m.meshIndex)
+				{
+				case 0:	// branches - Mario stumbles
+				case 1:	// branches - Mario stumbles
+					continue;
+				case 3: // barn animal food holder - Mario can get stuck on it.
+				case 7:	// Stone Statues - Mario can clip through them and fall into the void.
+					boundingBox = generateMeshBoundingBox(sm);
+					break;
+				}
+				break;
+			case TR::LevelID::LVL_TR1_3A: //The Lost Valley
+				switch (m.meshIndex)
+				{
+				case 0:	// branches - Mario stumbles
+				case 1:	// branches - Mario stumbles
+				case 2: // tree/bushes - Mario can get stuck
+				case 3: // tree/bushes - Mario can get stuck
+				case 4: // tree/bushes - Mario can get stuck
+				case 5: // tree/bushes - Mario can get stuck
+				case 6: // dead tree trunk get mario stuck. we will ignore it.
+				case 7: // trees - Mario can get stuck
+				case 8: // trees - Mario can get stuck
+					continue;
+				case 12: // skeleton - Mario stumbles
+				case 13: // skeleton - Mario stumbles
+					boundingBox = generateMeshBoundingBox(sm);
+					break;
+				}
+				break;
+			case TR::LevelID::LVL_TR1_8B: //Obelisk of Khamoon
+				switch (m.meshIndex)
+				{
+				// case 10: // Iron Bars with only 1 face - solved by viewbox size										
+				// 	boundingBox = generateMeshBoundingBox(sm);
+				// 	break;
+				}
+				break;
+			case TR::LevelID::LVL_TR1_10B: //Atlantis
+				switch (m.meshIndex)
+				{
+				case 0:	// weird flesh 1 surface walls
+				case 1:	// weird flesh 1 surface walls
+					boundingBox = generateMeshBoundingBox(sm);
+					break;
+				}
+				break;
+			}
+			
+			if(boundingBox)
+				d=boundingBox;
+			else if(d->fCount<2 || sm->vbox.minX==sm->vbox.maxX || sm->vbox.minY==sm->vbox.maxY || sm->vbox.minZ==sm->vbox.maxZ){
+				boundingBox = generateMeshBoundingBox(sm);
+				d=boundingBox;
+			}
+
+			// increment the surface count for this
+			for (int k = 0; k < d->fCount; k++)
+				obj.surfaceCount += (d->faces[k].triangle) ? 1 : 2;
+
+			obj.surfaces = (SM64Surface*)malloc(sizeof(SM64Surface) * obj.surfaceCount);
+			size_t surface_ind = 0;
+
+			// add the faces
+			for (int k = 0; k < d->fCount; k++)
+			{
+				TR::Face &f = d->faces[k];
+
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
+					{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
+					{(d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE},
+					{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
+				}};
+
+				if (!f.triangle)
+				{
+					obj.surfaces[surface_ind++] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
+						{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
+						{(d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE},
+						{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
+					}};
+				}
+			}
+
+			if(boundingBox!=NULL)
+			{
+				free(boundingBox->faces);
+				free(boundingBox->vertices);
+				free(boundingBox);
+				boundingBox=NULL;
+			}
+
+			meshes[(*room_meshes_count)++]=obj;
+		}
+
+		return meshes;
+	}
+
+    void createDynamicObjects()
+	{
+		// create collisions from entities (bridges, doors)
+		for (int i=0; i<level->entitiesCount; i++)
+		{
+			TR::Entity *e = &level->entities[i];
+			if (e->isEnemy() || e->isLara() || e->isSprite() || e->isPuzzleHole() || e->isPickup() || e->type == 169)
+				continue;
+
+			if (!(e->type >= 68 && e->type <= 70) && !e->isDoor() && !e->isBlock() && e->type != TR::Entity::MOVING_BLOCK && e->type != TR::Entity::TRAP_FLOOR && e->type != TR::Entity::TRAP_DOOR_1 && e->type != TR::Entity::TRAP_DOOR_2 && e->type != TR::Entity::DRAWBRIDGE)
+				continue;
+
+			TR::Model *model = &level->models[e->modelIndex - 1];
+			if (!model)
+				continue;
+
+			struct SM64SurfaceObject obj;
+			obj.surfaceCount = 0;
+			obj.transform.position[0] = e->x / MARIO_SCALE;
+			obj.transform.position[1] = -e->y / MARIO_SCALE;
+			obj.transform.position[2] = -e->z / MARIO_SCALE;
+			for (int j=0; j<3; j++) obj.transform.eulerRotation[j] = (j == 1) ? float(e->rotation) / M_PI * 180.f : 0;
+
+			// some code taken from extension.h below
+
+			// first increment the surface count
+			if (e->isBlock()) obj.surfaceCount += 12; // 6 sides, 2 triangles per side to form a quad
+			else if (e->type == TR::Entity::TRAP_FLOOR) obj.surfaceCount += 2; // floor
+			else
+			{
+				for (int c = 0; c < model->mCount; c++)
+				{
+					int index = level->meshOffsets[model->mStart + c];
+					if (index || model->mStart + c <= 0)
+					{
+						TR::Mesh &d = level->meshes[index];
+						for (int j = 0; j < d.fCount; j++)
+							obj.surfaceCount += (d.faces[j].triangle) ? 1 : 2;
+					}
+				}
+			}
+
+			// then create the surface and add the objects
+			obj.surfaces = (SM64Surface*)malloc(sizeof(SM64Surface) * obj.surfaceCount);
+			size_t surface_ind = 0;
+			vec3 offset(0,0,0);
+			bool doOffsetY = true;
+			int16 topPointSign = 1;
+			if (e->type >= 68 && e->type <= 70) topPointSign = -1;
+			else if (e->type == TR::Entity::TRAP_FLOOR)
+			{
+				offset.y = 512;
+				doOffsetY = false;
+			}
+			else if (e->isDoor())
+			{
+				offset.x = (512*cos(float(e->rotation)) - 512*sin(float(e->rotation))) * (1);
+				offset.z = (-512*sin(float(e->rotation)) - 512*cos(float(e->rotation))) * ((e->type == TR::Entity::DOOR_1 || e->type == TR::Entity::DOOR_2 || (e->type == TR::Entity::DOOR_3 && abs(cos(float(e->rotation))) == 1) || e->type == TR::Entity::DOOR_4 || e->type == TR::Entity::DOOR_5 ||e->type == TR::Entity::DOOR_6 || e->type == TR::Entity::DOOR_7 || e->type == TR::Entity::DOOR_8) ? -1 : 1);
+			}
+			else if (e->type == TR::Entity::TRAP_DOOR_1)
+			{
+				offset.x = 512*cos(float(e->rotation)) - 512*sin(float(e->rotation));
+				offset.z = 512*sin(float(e->rotation)) + 512*cos(float(e->rotation));
+				offset.y = -88;
+				doOffsetY = false;
+			}
+			else if (e->type == TR::Entity::TRAP_DOOR_2)
+			{
+				offset.x = 512*cos(float(e->rotation)) - 512*sin(float(e->rotation));
+				offset.z = -512*sin(float(e->rotation)) + 512*cos(float(e->rotation));
+				offset.y = -88;
+				doOffsetY = false;
+			}
+			else if (e->type == TR::Entity::DRAWBRIDGE)
+			{
+				offset.y = -20;
+				doOffsetY = false;
+				// before you go "yanderedev code":
+				// can't use switch() here because eulerRotation isn't an integer
+				if (obj.transform.eulerRotation[1] == 90)
+				{
+					offset.x = -384-128;
+					offset.z = -384-128;
+				}
+				else if (obj.transform.eulerRotation[1] == 270)
+				{
+					offset.x = 512;
+					offset.z = 512;
+				}
+				else if (obj.transform.eulerRotation[1] == 180)
+				{
+					offset.x = -384;
+					offset.z = 512;
+				}
+				else
+				{
+					offset.x = 384+128;
+					offset.z = -384-128;
+				}
+			}
+
+			if (e->isBlock())
+			{
+				// bottom of block
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
+
+				// left (Z+)
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, 128}, {128, 256, 128}, {-128, 256, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 256, 128}, {-128, 0, 128}, {128, 0, 128}}}; // top right, bottom left, bottom right
+
+				// right (Z-)
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, -128}, {-128, 256, -128}, {128, 256, -128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 256, -128}, {128, 0, -128}, {-128, 0, -128}}}; // top right, bottom left, bottom right
+
+				// back (X+)
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, -128}, {128, 256, -128}, {128, 256, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 256, 128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
+
+				// front (X-)
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, 128}, {-128, 256, 128}, {-128, 256, -128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 256, -128}, {-128, 0, -128}, {-128, 0, 128}}}; // top right, bottom left, bottom right
+
+				// top of block
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 256, 128}, {-128, 256, -128}, {-128, 256, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 256, -128}, {128, 256, 128}, {128, 256, -128}}}; // top right, bottom left, bottom right
+			}
+			else if (e->type == TR::Entity::TRAP_FLOOR)
+			{
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
+				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
+			}
+			else
+			{
+				for (int c = 0; c < model->mCount; c++)
+				{
+					int index = level->meshOffsets[model->mStart + c];
+					if (index || model->mStart + c <= 0)
+					{
+						TR::Mesh &d = level->meshes[index];
+						for (int j = 0; j < d.fCount; j++)
+						{
+							TR::Face &f = d.faces[j];
+
+							if (!offset.y) offset.y = topPointSign * max(offset.y, (float)d.vertices[f.vertices[0]].coord.y, max((float)d.vertices[f.vertices[1]].coord.y, (float)d.vertices[f.vertices[2]].coord.y, (f.triangle) ? 0.f : (float)d.vertices[f.vertices[3]].coord.y));
+
+							obj.surfaces[surface_ind] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
+								{(d.vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
+								{(d.vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[1]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[1]].coord.z)/IMARIO_SCALE},
+								{(d.vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
+							}};
+
+							if (!f.triangle)
+							{
+								surface_ind++;
+								obj.surfaces[surface_ind] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
+									{(d.vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
+									{(d.vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[3]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[3]].coord.z)/IMARIO_SCALE},
+									{(d.vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
+								}};
+							}
+
+							surface_ind++;
+						}
+					}
+				}
+			}
+			obj.transform.position[0] += offset.x/MARIO_SCALE;
+			obj.transform.position[1] += offset.y/MARIO_SCALE;
+			obj.transform.position[2] += offset.z/MARIO_SCALE;
+
+			// and finally add the object (this returns an uint32_t which is the object's ID)
+			struct MarioControllerObj cObj;
+			cObj.spawned = true;
+			cObj.ID = sm64_surface_object_create(&obj);
+			cObj.transform = obj.transform;
+			cObj.entity = e;
+			cObj.offset = offset;
+
+			dynamicObjects[dynamicObjectsCount++] = cObj;
+			free(obj.surfaces);
+		}
+	}
+
+    
+
+    void loadSM64Level(TR::Level *newLevel, IController *player)
+    {
+		level=newLevel;
+		controller = player;
+        #ifdef DEBUG_RENDER	
+        printf("Loading level %d\n", level->id);
+        #endif
+        sm64_level_init(level->roomsCount);
+
+        for(int roomId=0; roomId< level->roomsCount; roomId++)
+        {
+            int staticSurfacesCount;
+            struct SM64Surface *staticSurfaces = marioLoadRoomSurfaces(roomId, &staticSurfacesCount);
+
+            int roomMeshesCount;
+            struct SM64SurfaceObject *roomMeshes = marioLoadRoomMeshes(roomId, &roomMeshesCount);
+
+            sm64_level_load_room(roomId, staticSurfaces, staticSurfacesCount, roomMeshes, roomMeshesCount);
+
+            free(staticSurfaces);
+            for(int i=0; i<roomMeshesCount; i++)
+            {
+                free(roomMeshes[i].surfaces);
+            }
+            free(roomMeshes);	
+        }
+
+        createDynamicObjects();
+    }
+
+
+};
+
+#endif

--- a/src/levelsm64.h
+++ b/src/levelsm64.h
@@ -13,17 +13,8 @@ extern "C" {
 
 
 #include "core.h"
-// #include "game.h"
-// #include "lara.h"
-// #include "objects.h"
-// #include "sprite.h"
-// #include "enemy.h"
-// #include "inventory.h"
-// #include "mesh.h"
 #include "format.h"
-// #include "level.h"
 #include "controller.h"
-
 #include "marioMacros.h"
 
 struct MarioControllerObj
@@ -277,9 +268,11 @@ struct LevelSM64
 		case TR::LevelID::LVL_TR1_6:// Palace Midas
 			switch (meshIndex)
 			{
+				case 6: //railings at the balcony at the final level are 1 face thick and mario clips
+					return MESH_LOADING_BOUNDING_BOX;
 				case 14: // bushes - mario gets stuck
 				case 19: // small tree - mario gets stuck
-				return MESH_LOADING_DISCARD;
+					return MESH_LOADING_DISCARD;
 			}
 			break;
 		case TR::LevelID::LVL_TR1_7A:
@@ -547,34 +540,11 @@ struct LevelSM64
 
 			if (e->isBlock())
 			{
-				// bottom of block
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
-
-				// left (Z+)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 0, 128}, {128, 256, 128}, {-128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 256, 128}, {-128, 0, 128}, {128, 0, 128}}}; // top right, bottom left, bottom right
-
-				// right (Z-)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 0, -128}, {-128, 256, -128}, {128, 256, -128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 256, -128}, {128, 0, -128}, {-128, 0, -128}}}; // top right, bottom left, bottom right
-
-				// back (X+)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 0, -128}, {128, 256, -128}, {128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 256, 128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
-
-				// front (X-)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 0, 128}, {-128, 256, 128}, {-128, 256, -128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 256, -128}, {-128, 0, -128}, {-128, 0, 128}}}; // top right, bottom left, bottom right
-
-				// top of block
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 256, 128}, {-128, 256, -128}, {-128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 256, -128}, {128, 256, 128}, {128, 256, -128}}}; // top right, bottom left, bottom right
+				ADD_CUBE_GEOMETRY_NON_TRANSFORMED(obj.surfaces, surface_ind, -128, 128, 0, 256, -128, 128);
 			}
 			else if (e->type == TR::Entity::TRAP_FLOOR)
 			{
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE, {{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
+				ADD_RECTANGLE_HORIZONTAL_GEOMETRY_NON_TRANSFORMED(obj.surfaces, surface_ind, -128, 128, -128, 128);
 			}
 			else
 			{
@@ -793,8 +763,9 @@ struct LevelSM64
 				}
 			}
 		}
-
+		#ifdef DEBUG_RENDER	
 		printf("clips found: %d\n", clipsCount);
+		#endif
 	}
 
 	void createClipBlockers()
@@ -857,13 +828,28 @@ struct LevelSM64
 		//Hardcoded exceptions to avoid invisible collisions
 		switch (level->id)
 		{
+		case TR::LevelID::LVL_TR1_6: //Palace Midas
+			switch (currentRoomIndex)
+			{
+			case 25: //room with huge pillar that goes down
+				if(to==63)
+					return;
+				break;
+			case 63: //corridor that goes down the huge pillar
+				if(to==25)
+					return;
+				break;
+			}
+			break;
 		case TR::LVL_TR1_10B: //Atlantis
 			switch (currentRoomIndex)
 			{
 			case 47: //room with blocks and switches to trapdoors
 				if(to==84)
 					return;
+				break;
 			}
+			break;
 		}
 		
 

--- a/src/mario.h
+++ b/src/mario.h
@@ -35,17 +35,6 @@ struct MarioRenderState
 	MarioMesh mario;
 };
 
-struct MarioControllerObj
-{
-	MarioControllerObj() : ID(0), entity(NULL), spawned(false) {}
-
-	uint32_t ID;
-	struct SM64ObjectTransform transform;
-	TR::Entity* entity;
-	vec3 offset;
-	bool spawned;
-};
-
 struct MarioStaticMeshObj
 {
 	MarioStaticMeshObj() : ID(0), staticMesh(NULL) {}
@@ -71,10 +60,6 @@ struct Mario : Lara
 	bool reverseAnim;
 	float marioTicks;
 	bool postInit;
-	struct MarioControllerObj objs[4096];
-	struct MarioStaticMeshObj staticObjs[1024];
-	int objCount;
-	int staticObjCount;
 
 	Mesh* TRmarioMesh;
 
@@ -91,8 +76,6 @@ struct Mario : Lara
 		reverseAnim = false;
 		marioId = -1;
 		marioTicks = 0;
-		objCount = 0;
-		staticObjCount = 0;
 		movingBlock = NULL;
 		bowserSwing = NULL;
 		bowserAngle = 0;
@@ -120,24 +103,9 @@ struct Mario : Lara
 		TRmarioMesh = new Mesh((Index*)marioRenderState.mario.index, marioRenderState.mario.num_vertices, NULL, 0, 1, true, true);
 		TRmarioMesh->initMario(&marioGeometry);
 
-		
-		if (!game->getLara(0) || !game->getLara(0)->isMario) 
-		{
-			#ifdef DEBUG_RENDER	
-			printf("Loading level %d\n", level->id);
-			#endif
-			sm64_level_init(level->roomsCount);
-			for(int i=0; i< level->roomsCount; i++)
-			{
-				marioLoadRoom(i);	
-			}
-		}
-
-		int nearRooms[256];
-		int nearRoomsCount=0;
-		game->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
-		marioId = sm64_mario_create(pos.x/MARIO_SCALE, -pos.y/MARIO_SCALE, -pos.z/MARIO_SCALE, 0, 0, 0, 0, nearRooms, nearRoomsCount);
-		if (marioId >= 0) sm64_set_mario_faceangle(marioId, (int16_t)((-angle.y + M_PI) / M_PI * 32768.0f));
+		#ifdef DEBUG_RENDER	
+        printf("pre loading Mario\n");
+        #endif
 
 		lastPos[0] = currPos[0] = pos.x;
 		lastPos[1] = currPos[1] = -pos.y;
@@ -149,8 +117,6 @@ struct Mario : Lara
 		switchSndPlayed = false;
 
 		animation.setAnim(ANIM_STAND);
-
-		postInitMario();
 	}
 	
 	virtual ~Mario()
@@ -162,8 +128,6 @@ struct Mario : Lara
 		TRmarioMesh->iBuffer = NULL;
 		free(marioRenderState.mario.index);
 		delete TRmarioMesh;
-
-		sm64_level_unload();
 
 		for (int i=0; i<0x22; i++)
 			sm64_stop_background_music(i);
@@ -182,193 +146,6 @@ struct Mario : Lara
 		game->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
 		marioId = sm64_mario_create(pos.x/MARIO_SCALE, -pos.y/MARIO_SCALE, -pos.z/MARIO_SCALE, 0, 0, 0, 0, nearRooms, nearRoomsCount);
 		if (marioId >= 0) sm64_set_mario_faceangle(marioId, (int16_t)((-angle + M_PI) / M_PI * 32768.0f));
-	}
-
-	void postInitMario()
-	{
-		if (postInit) return;
-		postInit = true;
-
-		// create collisions from entities (bridges, doors)
-		for (int i=0; i<level->entitiesCount; i++)
-		{
-			TR::Entity *e = &level->entities[i];
-			if (e->isEnemy() || e->isLara() || e->isSprite() || e->isPuzzleHole() || e->isPickup() || e->type == 169)
-				continue;
-
-			if (!(e->type >= 68 && e->type <= 70) && !e->isDoor() && !e->isBlock() && e->type != TR::Entity::MOVING_BLOCK && e->type != TR::Entity::TRAP_FLOOR && e->type != TR::Entity::TRAP_DOOR_1 && e->type != TR::Entity::TRAP_DOOR_2 && e->type != TR::Entity::DRAWBRIDGE)
-				continue;
-
-			TR::Model *model = &level->models[e->modelIndex - 1];
-			if (!model)
-				continue;
-
-			struct SM64SurfaceObject obj;
-			obj.surfaceCount = 0;
-			obj.transform.position[0] = e->x / MARIO_SCALE;
-			obj.transform.position[1] = -e->y / MARIO_SCALE;
-			obj.transform.position[2] = -e->z / MARIO_SCALE;
-			for (int j=0; j<3; j++) obj.transform.eulerRotation[j] = (j == 1) ? float(e->rotation) / M_PI * 180.f : 0;
-
-			// some code taken from extension.h below
-
-			// first increment the surface count
-			if (e->isBlock()) obj.surfaceCount += 12; // 6 sides, 2 triangles per side to form a quad
-			else if (e->type == TR::Entity::TRAP_FLOOR) obj.surfaceCount += 2; // floor
-			else
-			{
-				for (int c = 0; c < model->mCount; c++)
-				{
-					int index = level->meshOffsets[model->mStart + c];
-					if (index || model->mStart + c <= 0)
-					{
-						TR::Mesh &d = level->meshes[index];
-						for (int j = 0; j < d.fCount; j++)
-							obj.surfaceCount += (d.faces[j].triangle) ? 1 : 2;
-					}
-				}
-			}
-
-			// then create the surface and add the objects
-			obj.surfaces = (SM64Surface*)malloc(sizeof(SM64Surface) * obj.surfaceCount);
-			size_t surface_ind = 0;
-			vec3 offset(0,0,0);
-			bool doOffsetY = true;
-			int16 topPointSign = 1;
-			if (e->type >= 68 && e->type <= 70) topPointSign = -1;
-			else if (e->type == TR::Entity::TRAP_FLOOR)
-			{
-				offset.y = 512;
-				doOffsetY = false;
-			}
-			else if (e->isDoor())
-			{
-				offset.x = (512*cos(float(e->rotation)) - 512*sin(float(e->rotation))) * (1);
-				offset.z = (-512*sin(float(e->rotation)) - 512*cos(float(e->rotation))) * ((e->type == TR::Entity::DOOR_1 || e->type == TR::Entity::DOOR_2 || (e->type == TR::Entity::DOOR_3 && abs(cos(float(e->rotation))) == 1) || e->type == TR::Entity::DOOR_4 || e->type == TR::Entity::DOOR_5 ||e->type == TR::Entity::DOOR_6 || e->type == TR::Entity::DOOR_7 || e->type == TR::Entity::DOOR_8) ? -1 : 1);
-			}
-			else if (e->type == TR::Entity::TRAP_DOOR_1)
-			{
-				offset.x = 512*cos(float(e->rotation)) - 512*sin(float(e->rotation));
-				offset.z = 512*sin(float(e->rotation)) + 512*cos(float(e->rotation));
-				offset.y = -88;
-				doOffsetY = false;
-			}
-			else if (e->type == TR::Entity::TRAP_DOOR_2)
-			{
-				offset.x = 512*cos(float(e->rotation)) - 512*sin(float(e->rotation));
-				offset.z = -512*sin(float(e->rotation)) + 512*cos(float(e->rotation));
-				offset.y = -88;
-				doOffsetY = false;
-			}
-			else if (e->type == TR::Entity::DRAWBRIDGE)
-			{
-				offset.y = -20;
-				doOffsetY = false;
-				// before you go "yanderedev code":
-				// can't use switch() here because eulerRotation isn't an integer
-				if (obj.transform.eulerRotation[1] == 90)
-				{
-					offset.x = -384-128;
-					offset.z = -384-128;
-				}
-				else if (obj.transform.eulerRotation[1] == 270)
-				{
-					offset.x = 512;
-					offset.z = 512;
-				}
-				else if (obj.transform.eulerRotation[1] == 180)
-				{
-					offset.x = -384;
-					offset.z = 512;
-				}
-				else
-				{
-					offset.x = 384+128;
-					offset.z = -384-128;
-				}
-			}
-
-			if (e->isBlock())
-			{
-				// bottom of block
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
-
-				// left (Z+)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, 128}, {128, 256, 128}, {-128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 256, 128}, {-128, 0, 128}, {128, 0, 128}}}; // top right, bottom left, bottom right
-
-				// right (Z-)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, -128}, {-128, 256, -128}, {128, 256, -128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 256, -128}, {128, 0, -128}, {-128, 0, -128}}}; // top right, bottom left, bottom right
-
-				// back (X+)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, -128}, {128, 256, -128}, {128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 256, 128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
-
-				// front (X-)
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, 128}, {-128, 256, 128}, {-128, 256, -128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 256, -128}, {-128, 0, -128}, {-128, 0, 128}}}; // top right, bottom left, bottom right
-
-				// top of block
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 256, 128}, {-128, 256, -128}, {-128, 256, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 256, -128}, {128, 256, 128}, {128, 256, -128}}}; // top right, bottom left, bottom right
-			}
-			else if (e->type == TR::Entity::TRAP_FLOOR)
-			{
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{128, 0, 128}, {-128, 0, -128}, {-128, 0, 128}}}; // bottom left, top right, top left
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT,0,TERRAIN_STONE,{{-128, 0, -128}, {128, 0, 128}, {128, 0, -128}}}; // top right, bottom left, bottom right
-			}
-			else
-			{
-				for (int c = 0; c < model->mCount; c++)
-				{
-					int index = level->meshOffsets[model->mStart + c];
-					if (index || model->mStart + c <= 0)
-					{
-						TR::Mesh &d = level->meshes[index];
-						for (int j = 0; j < d.fCount; j++)
-						{
-							TR::Face &f = d.faces[j];
-
-							if (!offset.y) offset.y = topPointSign * max(offset.y, (float)d.vertices[f.vertices[0]].coord.y, max((float)d.vertices[f.vertices[1]].coord.y, (float)d.vertices[f.vertices[2]].coord.y, (f.triangle) ? 0.f : (float)d.vertices[f.vertices[3]].coord.y));
-
-							obj.surfaces[surface_ind] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
-								{(d.vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
-								{(d.vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[1]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[1]].coord.z)/IMARIO_SCALE},
-								{(d.vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
-							}};
-
-							if (!f.triangle)
-							{
-								surface_ind++;
-								obj.surfaces[surface_ind] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
-									{(d.vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
-									{(d.vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[3]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[3]].coord.z)/IMARIO_SCALE},
-									{(d.vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d.vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
-								}};
-							}
-
-							surface_ind++;
-						}
-					}
-				}
-			}
-			obj.transform.position[0] += offset.x/MARIO_SCALE;
-			obj.transform.position[1] += offset.y/MARIO_SCALE;
-			obj.transform.position[2] += offset.z/MARIO_SCALE;
-
-			// and finally add the object (this returns an uint32_t which is the object's ID)
-			struct MarioControllerObj cObj;
-			cObj.spawned = true;
-			cObj.ID = sm64_surface_object_create(&obj);
-			cObj.transform = obj.transform;
-			cObj.entity = e;
-			cObj.offset = offset;
-
-			objs[objCount++] = cObj;
-			free(obj.surfaces);
-		}
 	}
 
 	vec3 getPos() {return vec3(marioState.position[0], -marioState.position[1], -marioState.position[2]);}
@@ -1360,337 +1137,6 @@ struct Mario : Lara
 		}
 	}
 
-	struct SM64Surface* marioLoadRoomSurfaces(int roomId, int *room_surfaces_count)
-	{
-		*room_surfaces_count = 0;
-		size_t level_surface_i = 0;
-
-		TR::Room &room = level->rooms[roomId];
-		TR::Room::Data &d = room.data;
-
-		// Count the number of static surface triangles
-		for (int j = 0; j < d.fCount; j++)
-		{
-			TR::Face &f = d.faces[j];
-			if (f.water) continue;
-
-			*room_surfaces_count += (f.triangle) ? 1 : 2;
-		}
-
-		struct SM64Surface *collision_surfaces = (struct SM64Surface *)malloc(sizeof(struct SM64Surface) * (*room_surfaces_count));
-
-		// Generate all static surface triangles
-		for (int cface = 0; cface < d.fCount; cface++)
-		{
-			TR::Face &f = d.faces[cface];
-				if (f.water) continue;
-
-			int16 x[2] = {d.vertices[f.vertices[0]].pos.x, 0};
-			int16 z[2] = {d.vertices[f.vertices[0]].pos.z, 0};
-			for (int j=1; j<3; j++)
-			{
-				if (x[0] != d.vertices[f.vertices[j]].pos.x) x[1] = d.vertices[f.vertices[j]].pos.x;
-				if (z[0] != d.vertices[f.vertices[j]].pos.z) z[1] = d.vertices[f.vertices[j]].pos.z;
-			}
-
-			float midX = (x[0] + x[1]) / 2.f;
-			float topY = max(d.vertices[f.vertices[0]].pos.y, max(d.vertices[f.vertices[1]].pos.y, d.vertices[f.vertices[2]].pos.y));
-			float midZ = (z[0] + z[1]) / 2.f;
-
-			TR::Level::FloorInfo info;
-			getFloorInfo(roomId, vec3(room.info.x + midX, topY, room.info.z + midZ), info);
-			bool slippery = (abs(info.slantX) > 2 || abs(info.slantZ) > 2);
-
-			ADD_FACE(collision_surfaces, level_surface_i, room, d, f, slippery);
-		}
-
-		return collision_surfaces;
-	}
-
-	TR::Mesh *generateMeshBoundingBox(TR::StaticMesh *sm)
-	{
-		Box box;
-		sm->getBox(true, box);
-		
-		TR::Mesh *boundingBox = (TR::Mesh *) malloc(sizeof(TR::Mesh));
-		boundingBox->fCount = 12;
-		boundingBox->faces = (TR::Face *)malloc(sizeof(TR::Face)*boundingBox->fCount);
-
-		boundingBox->vCount = 8;
-		boundingBox->vertices = (TR::Mesh::Vertex *)malloc(sizeof(TR::Mesh::Vertex)*boundingBox->vCount);
-
-		boundingBox->vertices[0].coord.x=box.min.x;
-		boundingBox->vertices[0].coord.y=box.min.y;
-		boundingBox->vertices[0].coord.z=box.min.z;
-
-		boundingBox->vertices[1].coord.x=box.min.x;
-		boundingBox->vertices[1].coord.y=box.max.y;
-		boundingBox->vertices[1].coord.z=box.min.z;
-
-		boundingBox->vertices[2].coord.x=box.max.x;
-		boundingBox->vertices[2].coord.y=box.max.y;
-		boundingBox->vertices[2].coord.z=box.min.z;
-
-		boundingBox->vertices[3].coord.x=box.max.x;
-		boundingBox->vertices[3].coord.y=box.min.y;
-		boundingBox->vertices[3].coord.z=box.min.z;
-
-		boundingBox->vertices[4].coord.x=box.min.x;
-		boundingBox->vertices[4].coord.y=box.min.y;
-		boundingBox->vertices[4].coord.z=box.max.z;
-
-		boundingBox->vertices[5].coord.x=box.min.x;
-		boundingBox->vertices[5].coord.y=box.max.y;
-		boundingBox->vertices[5].coord.z=box.max.z;
-
-		boundingBox->vertices[6].coord.x=box.max.x;
-		boundingBox->vertices[6].coord.y=box.max.y;
-		boundingBox->vertices[6].coord.z=box.max.z;
-		
-		boundingBox->vertices[7].coord.x=box.max.x;
-		boundingBox->vertices[7].coord.y=box.min.y;
-		boundingBox->vertices[7].coord.z=box.max.z;
-
-		boundingBox->faces[0].triangle=1;
-		boundingBox->faces[0].vertices[0]=2;
-		boundingBox->faces[0].vertices[1]=1;
-		boundingBox->faces[0].vertices[2]=0;
-
-		boundingBox->faces[1].triangle=1;
-		boundingBox->faces[1].vertices[0]=0;
-		boundingBox->faces[1].vertices[1]=3;
-		boundingBox->faces[1].vertices[2]=2;
-
-		boundingBox->faces[2].triangle=1;
-		boundingBox->faces[2].vertices[0]=2;
-		boundingBox->faces[2].vertices[1]=3;
-		boundingBox->faces[2].vertices[2]=7;
-
-		boundingBox->faces[3].triangle=1;
-		boundingBox->faces[3].vertices[0]=7;
-		boundingBox->faces[3].vertices[1]=6;
-		boundingBox->faces[3].vertices[2]=2;
-
-		boundingBox->faces[4].triangle=1;
-		boundingBox->faces[4].vertices[0]=6;
-		boundingBox->faces[4].vertices[1]=7;
-		boundingBox->faces[4].vertices[2]=4;
-
-		boundingBox->faces[5].triangle=1;
-		boundingBox->faces[5].vertices[0]=4;
-		boundingBox->faces[5].vertices[1]=5;
-		boundingBox->faces[5].vertices[2]=6;
-
-		boundingBox->faces[6].triangle=1;
-		boundingBox->faces[6].vertices[0]=4;
-		boundingBox->faces[6].vertices[1]=0;
-		boundingBox->faces[6].vertices[2]=5;
-
-		boundingBox->faces[7].triangle=1;
-		boundingBox->faces[7].vertices[0]=0;
-		boundingBox->faces[7].vertices[1]=1;
-		boundingBox->faces[7].vertices[2]=5;
-
-		boundingBox->faces[8].triangle=1;
-		boundingBox->faces[8].vertices[0]=7;
-		boundingBox->faces[8].vertices[1]=3;
-		boundingBox->faces[8].vertices[2]=0;
-
-		boundingBox->faces[9].triangle=1;
-		boundingBox->faces[9].vertices[0]=0;
-		boundingBox->faces[9].vertices[1]=4;
-		boundingBox->faces[9].vertices[2]=7;
-
-		boundingBox->faces[10].triangle=1;
-		boundingBox->faces[10].vertices[0]=6;
-		boundingBox->faces[10].vertices[1]=5;
-		boundingBox->faces[10].vertices[2]=1;
-
-		boundingBox->faces[11].triangle=1;
-		boundingBox->faces[11].vertices[0]=1;
-		boundingBox->faces[11].vertices[1]=2;
-		boundingBox->faces[11].vertices[2]=6;
-
-		return boundingBox;
-	}
-
-	struct SM64SurfaceObject* marioLoadRoomMeshes(int roomId, int *room_meshes_count)
-	{
-		TR::Room &room = level->rooms[roomId];
-		TR::Room::Data &d = room.data;
-
-		*room_meshes_count = 0;
-
-		struct SM64SurfaceObject *meshes = (struct SM64SurfaceObject*)malloc(sizeof(struct SM64SurfaceObject)*room.meshesCount);
-
-		for (int j = 0; j < room.meshesCount; j++)
-		{
-			TR::Room::Mesh &m  = room.meshes[j];
-			TR::StaticMesh *sm = &level->staticMeshes[m.meshIndex];
-			if (sm->flags != 2 || !level->meshOffsets[sm->mesh]) {
-				continue;
-			}
-
-			// define the surface object
-			struct SM64SurfaceObject obj;
-			obj.surfaceCount = 0;
-			obj.transform.position[0] = m.x / MARIO_SCALE;
-			obj.transform.position[1] = -m.y / MARIO_SCALE;
-			obj.transform.position[2] = -m.z / MARIO_SCALE;
-			for (int k=0; k<3; k++) obj.transform.eulerRotation[k] = (k == 1) ? float(m.rotation) / M_PI * 180.f : 0;
-
-			TR::Mesh *d = &(level->meshes[level->meshOffsets[sm->mesh]]);
-			TR::Mesh *boundingBox = NULL;
-
-			switch(level->id)
-			{
-			case TR::LevelID::LVL_TR1_GYM:
-				switch (m.meshIndex)
-				{
-				case 0:	// plant - Mario can get stuck
-				case 1:	// plant - Mario can get stuck
-				case 2: // plant - Mario can get stuck
-				case 3: // plant - Mario can get stuck
-				case 4: // branches - Mario can get stuck
-					continue;
-				case 7: //harp - Mario can get stuck
-				case 8: //piano	- Martio can get stuck
-				case 11: //pedestal - Mario can get stuck between it and the columns
-				case 13: //handcart - Mario can get stuck
-					boundingBox = generateMeshBoundingBox(sm);					
-					break;
-				}
-				break;
-			case TR::LevelID::LVL_TR1_1: //Caves
-				switch (m.meshIndex)
-				{
-				case 0:	// branches - Mario stumbles
-				case 1:	// branches	- Mario stumbles
-				case 7:	// ice stalactite - Mario stumbles
-					continue;
-				// case 2: //wood fence blocking path to exit - solved by viewbox size
-				// 	boundingBox = generateMeshBoundingBox(sm);					
-				// 	break;
-				}
-				break;
-			case TR::LevelID::LVL_TR1_2: //City of Vilcabamba
-				switch (m.meshIndex)
-				{
-				case 0:	// branches - Mario stumbles
-				case 1:	// branches - Mario stumbles
-					continue;
-				case 3: // barn animal food holder - Mario can get stuck on it.
-				case 7:	// Stone Statues - Mario can clip through them and fall into the void.
-					boundingBox = generateMeshBoundingBox(sm);
-					break;
-				}
-				break;
-			case TR::LevelID::LVL_TR1_3A: //The Lost Valley
-				switch (m.meshIndex)
-				{
-				case 0:	// branches - Mario stumbles
-				case 1:	// branches - Mario stumbles
-				case 2: // tree/bushes - Mario can get stuck
-				case 3: // tree/bushes - Mario can get stuck
-				case 4: // tree/bushes - Mario can get stuck
-				case 5: // tree/bushes - Mario can get stuck
-				case 6: // dead tree trunk get mario stuck. we will ignore it.
-				case 7: // trees - Mario can get stuck
-				case 8: // trees - Mario can get stuck
-					continue;
-				case 12: // skeleton - Mario stumbles
-				case 13: // skeleton - Mario stumbles
-					boundingBox = generateMeshBoundingBox(sm);
-					break;
-				}
-				break;
-			case TR::LevelID::LVL_TR1_8B: //Obelisk of Khamoon
-				switch (m.meshIndex)
-				{
-				// case 10: // Iron Bars with only 1 face - solved by viewbox size										
-				// 	boundingBox = generateMeshBoundingBox(sm);
-				// 	break;
-				}
-				break;
-			case TR::LevelID::LVL_TR1_10B: //Atlantis
-				switch (m.meshIndex)
-				{
-				case 0:	// weird flesh 1 surface walls
-				case 1:	// weird flesh 1 surface walls
-					boundingBox = generateMeshBoundingBox(sm);
-					break;
-				}
-				break;
-			}
-			
-			if(boundingBox)
-				d=boundingBox;
-			else if(d->fCount<2 || sm->vbox.minX==sm->vbox.maxX || sm->vbox.minY==sm->vbox.maxY || sm->vbox.minZ==sm->vbox.maxZ){
-				boundingBox = generateMeshBoundingBox(sm);
-				d=boundingBox;
-			}
-
-			// increment the surface count for this
-			for (int k = 0; k < d->fCount; k++)
-				obj.surfaceCount += (d->faces[k].triangle) ? 1 : 2;
-
-			obj.surfaces = (SM64Surface*)malloc(sizeof(SM64Surface) * obj.surfaceCount);
-			size_t surface_ind = 0;
-
-			// add the faces
-			for (int k = 0; k < d->fCount; k++)
-			{
-				TR::Face &f = d->faces[k];
-
-				obj.surfaces[surface_ind++] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
-					{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
-					{(d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE},
-					{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
-				}};
-
-				if (!f.triangle)
-				{
-					obj.surfaces[surface_ind++] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, {
-						{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE},
-						{(d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE},
-						{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE},
-					}};
-				}
-			}
-
-			if(boundingBox!=NULL)
-			{
-				free(boundingBox->faces);
-				free(boundingBox->vertices);
-				free(boundingBox);
-				boundingBox=NULL;
-			}
-
-			meshes[(*room_meshes_count)++]=obj;
-		}
-
-		return meshes;
-	}
-
-	void marioLoadRoom(int roomId)
-	{
-		int staticSurfacesCount;
-		struct SM64Surface *staticSurfaces = marioLoadRoomSurfaces(roomId, &staticSurfacesCount);
-
-		int roomMeshesCount;
-		struct SM64SurfaceObject *roomMeshes = marioLoadRoomMeshes(roomId, &roomMeshesCount);
-
-		sm64_level_load_room(roomId, staticSurfaces, staticSurfacesCount, roomMeshes, roomMeshesCount);
-
-		free(staticSurfaces);
-		for(int i=0; i<roomMeshesCount; i++)
-		{
-			free(roomMeshes[i].surfaces);
-		}
-		free(roomMeshes);
-		
-	}
-
 
 	bool arrayContainsValue(int val, int *array, int arraySize){
 		for(int i=0; i<arraySize; i++)
@@ -1751,7 +1197,17 @@ struct Mario : Lara
 	}
 
 	void update()
-	{		
+	{
+		if(marioId==-1)
+		{
+			printf("actual mario loading\n");
+			int nearRooms[256];
+			int nearRoomsCount=0;
+			game->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
+			marioId = sm64_mario_create(pos.x/MARIO_SCALE, -pos.y/MARIO_SCALE, -pos.z/MARIO_SCALE, 0, 0, 0, 0, nearRooms, nearRoomsCount);
+			if (marioId >= 0) sm64_set_mario_faceangle(marioId, (int16_t)((-angle.y + M_PI) / M_PI * 32768.0f));
+		}
+
 		updateMarioVisibleRooms();
 		if (level->isCutsceneLevel()) {
 			updateAnimation(true);
@@ -1790,9 +1246,9 @@ struct Mario : Lara
 			updateState();
 			Controller::update();
 
-			for (int i=0; i<objCount; i++)
+			for (int i=0; i< levelSM64->dynamicObjectsCount ; i++)
 			{
-				struct MarioControllerObj *obj = &objs[i];
+				struct MarioControllerObj *obj = &(levelSM64->dynamicObjects[i]);
 				if (obj->entity && obj->entity->isDoor() && !obj->spawned && !((Controller*)obj->entity->controller)->isActive()) // door closed, bring back
 				{
 					// LAZY SOLUTION BECAUSE DIFFICULT

--- a/src/mario.h
+++ b/src/mario.h
@@ -143,7 +143,7 @@ struct Mario : Lara
 
 		int nearRooms[256];
 		int nearRoomsCount=0;
-		game->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
+		levelSM64->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
 		marioId = sm64_mario_create(pos.x/MARIO_SCALE, -pos.y/MARIO_SCALE, -pos.z/MARIO_SCALE, 0, 0, 0, 0, nearRooms, nearRoomsCount);
 		if (marioId >= 0) sm64_set_mario_faceangle(marioId, (int16_t)((-angle + M_PI) / M_PI * 32768.0f));
 	}
@@ -1174,7 +1174,7 @@ struct Mario : Lara
 		
 		int nearRooms[256];
 		int nearRoomsCount=0;
-		game->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 2);
+		levelSM64->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 2);
 
 
 		#ifdef DEBUG_RENDER			
@@ -1203,7 +1203,7 @@ struct Mario : Lara
 			printf("actual mario loading\n");
 			int nearRooms[256];
 			int nearRoomsCount=0;
-			game->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
+			levelSM64->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
 			marioId = sm64_mario_create(pos.x/MARIO_SCALE, -pos.y/MARIO_SCALE, -pos.z/MARIO_SCALE, 0, 0, 0, 0, nearRooms, nearRoomsCount);
 			if (marioId >= 0) sm64_set_mario_faceangle(marioId, (int16_t)((-angle.y + M_PI) / M_PI * 32768.0f));
 		}

--- a/src/marioMacros.h
+++ b/src/marioMacros.h
@@ -9,135 +9,149 @@ extern "C" {
 	#include <libsm64/src/decomp/include/surface_terrains.h>
 }
 
-#define ADD_FACE(surfaces, surface_ind, room, d, f, slippery) \
-	surfaces[surface_ind++] = {(int16_t)(slippery ? SURFACE_SLIPPERY : SURFACE_NOT_SLIPPERY), 0, TERRAIN_STONE, { \
-		{(room.info.x + d.vertices[f.vertices[2]].pos.x)/IMARIO_SCALE, -d.vertices[f.vertices[2]].pos.y/IMARIO_SCALE, -(room.info.z + d.vertices[f.vertices[2]].pos.z)/IMARIO_SCALE}, \
-		{(room.info.x + d.vertices[f.vertices[1]].pos.x)/IMARIO_SCALE, -d.vertices[f.vertices[1]].pos.y/IMARIO_SCALE, -(room.info.z + d.vertices[f.vertices[1]].pos.z)/IMARIO_SCALE}, \
-		{(room.info.x + d.vertices[f.vertices[0]].pos.x)/IMARIO_SCALE, -d.vertices[f.vertices[0]].pos.y/IMARIO_SCALE, -(room.info.z + d.vertices[f.vertices[0]].pos.z)/IMARIO_SCALE}, \
+#define ADD_ROOM_FACE_ABSOLUTE(surfaces, surface_ind, room, d, f, slippery, roomIndex, faceIndex) \
+	surfaces[surface_ind++] = {(int16_t)(slippery ? SURFACE_SLIPPERY : SURFACE_NOT_SLIPPERY), 0, TERRAIN_STONE, roomIndex, faceIndex, { \
+		{(room.info.x + d->vertices[f.vertices[2]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[2]].pos.z)/IMARIO_SCALE}, \
+		{(room.info.x + d->vertices[f.vertices[1]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[1]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[1]].pos.z)/IMARIO_SCALE}, \
+		{(room.info.x + d->vertices[f.vertices[0]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[0]].pos.z)/IMARIO_SCALE}, \
 	}}; \
 	if (!f.triangle) \
 	{ \
-		surfaces[surface_ind++] = {(int16_t)(slippery ? SURFACE_SLIPPERY : SURFACE_NOT_SLIPPERY), 0, TERRAIN_STONE, { \
-			{(room.info.x + d.vertices[f.vertices[0]].pos.x)/IMARIO_SCALE, -d.vertices[f.vertices[0]].pos.y/IMARIO_SCALE, -(room.info.z + d.vertices[f.vertices[0]].pos.z)/IMARIO_SCALE}, \
-			{(room.info.x + d.vertices[f.vertices[3]].pos.x)/IMARIO_SCALE, -d.vertices[f.vertices[3]].pos.y/IMARIO_SCALE, -(room.info.z + d.vertices[f.vertices[3]].pos.z)/IMARIO_SCALE}, \
-			{(room.info.x + d.vertices[f.vertices[2]].pos.x)/IMARIO_SCALE, -d.vertices[f.vertices[2]].pos.y/IMARIO_SCALE, -(room.info.z + d.vertices[f.vertices[2]].pos.z)/IMARIO_SCALE}, \
+		surfaces[surface_ind++] = {(int16_t)(slippery ? SURFACE_SLIPPERY : SURFACE_NOT_SLIPPERY), 0, TERRAIN_STONE, roomIndex, faceIndex, { \
+			{(room.info.x + d->vertices[f.vertices[0]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[0]].pos.z)/IMARIO_SCALE}, \
+			{(room.info.x + d->vertices[f.vertices[3]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[3]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[3]].pos.z)/IMARIO_SCALE}, \
+			{(room.info.x + d->vertices[f.vertices[2]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[2]].pos.z)/IMARIO_SCALE}, \
 		}}; \
 	}
 
-#define ADD_FACE_COORD_ROOM_MESH(surfaces, surface_ind, m, d, f) \
-	surfaces[surface_ind++] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, { \
-		{(m.x + d.vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(m.y + d.vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(m.z + d.vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
-		{(m.x + d.vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -(m.y + d.vertices[f.vertices[1]].coord.y)/IMARIO_SCALE, -(m.z + d.vertices[f.vertices[1]].coord.z)/IMARIO_SCALE}, \
-		{(m.x + d.vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(m.y + d.vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(m.z + d.vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
+
+#define ADD_MESH_FACE_RELATIVE(surfaces, surface_ind, d, f) \
+	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, -1, -1, { \
+		{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
+		{(d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[1]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE}, \
+		{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
 	}}; \
 	if (!f.triangle) \
 	{ \
-		surfaces[surface_ind++] = {SURFACE_DEFAULT, 0, TERRAIN_STONE, { \
-			{(m.x + d.vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -(m.y + d.vertices[f.vertices[0]].coord.y)/IMARIO_SCALE, -(m.z + d.vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
-			{(m.x + d.vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -(m.y + d.vertices[f.vertices[3]].coord.y)/IMARIO_SCALE, -(m.z + d.vertices[f.vertices[3]].coord.z)/IMARIO_SCALE}, \
-			{(m.x + d.vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -(m.y + d.vertices[f.vertices[2]].coord.y)/IMARIO_SCALE, -(m.z + d.vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
+		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, -1, -1, { \
+			{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
+			{(d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[3]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE}, \
+			{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
 		}}; \
 	}
+
+#define ADD_MESH_FACE_ABSOLUTE(surfaces, surface_ind, room, d, f) \
+	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, -1, -1, { \
+		{(room.info.x + d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
+		{(room.info.x + d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[1]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE}, \
+		{(room.info.x + d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
+	}}; \
+	if (!f.triangle) \
+	{ \
+		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, -1, -1, { \
+			{(room.info.x + d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
+			{(room.info.x + d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[3]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE}, \
+			{(room.info.x + d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
+		}}; \
+	}
+
+#define CREATE_BOUNDING_BOX(boundingBox, minx, maxx, miny, maxy, minz, maxz) \
+	boundingBox->vertices[0].coord.x=minx; \
+	boundingBox->vertices[0].coord.y=miny; \
+	boundingBox->vertices[0].coord.z=minz; \
+ \
+	boundingBox->vertices[1].coord.x=minx; \
+	boundingBox->vertices[1].coord.y=maxy; \
+	boundingBox->vertices[1].coord.z=minz; \
+ \
+	boundingBox->vertices[2].coord.x=maxx; \
+	boundingBox->vertices[2].coord.y=maxy; \
+	boundingBox->vertices[2].coord.z=minz; \
+ \
+	boundingBox->vertices[3].coord.x=maxx; \
+	boundingBox->vertices[3].coord.y=miny; \
+	boundingBox->vertices[3].coord.z=minz; \
+ \
+	boundingBox->vertices[4].coord.x=minx; \
+	boundingBox->vertices[4].coord.y=miny; \
+	boundingBox->vertices[4].coord.z=maxz; \
+ \
+	boundingBox->vertices[5].coord.x=minx; \
+	boundingBox->vertices[5].coord.y=maxy; \
+	boundingBox->vertices[5].coord.z=maxz; \
+ \
+	boundingBox->vertices[6].coord.x=maxx; \
+	boundingBox->vertices[6].coord.y=maxy; \
+	boundingBox->vertices[6].coord.z=maxz; \
+ \
+	boundingBox->vertices[7].coord.x=maxx; \
+	boundingBox->vertices[7].coord.y=miny; \
+	boundingBox->vertices[7].coord.z=maxz; \
+ \
+	boundingBox->faces[0].triangle=1; \
+	boundingBox->faces[0].vertices[0]=2; \
+	boundingBox->faces[0].vertices[1]=1; \
+	boundingBox->faces[0].vertices[2]=0; \
+ \
+	boundingBox->faces[1].triangle=1; \
+	boundingBox->faces[1].vertices[0]=0; \
+	boundingBox->faces[1].vertices[1]=3; \
+	boundingBox->faces[1].vertices[2]=2; \
+\
+	boundingBox->faces[2].triangle=1; \
+	boundingBox->faces[2].vertices[0]=2; \
+	boundingBox->faces[2].vertices[1]=3; \
+	boundingBox->faces[2].vertices[2]=7; \
+\
+	boundingBox->faces[3].triangle=1; \
+	boundingBox->faces[3].vertices[0]=7; \
+	boundingBox->faces[3].vertices[1]=6; \
+	boundingBox->faces[3].vertices[2]=2; \
+\
+	boundingBox->faces[4].triangle=1; \
+	boundingBox->faces[4].vertices[0]=6; \
+	boundingBox->faces[4].vertices[1]=7; \
+	boundingBox->faces[4].vertices[2]=4; \
+\
+	boundingBox->faces[5].triangle=1; \
+	boundingBox->faces[5].vertices[0]=4; \
+	boundingBox->faces[5].vertices[1]=5; \
+	boundingBox->faces[5].vertices[2]=6; \
+\
+	boundingBox->faces[6].triangle=1; \
+	boundingBox->faces[6].vertices[0]=4; \
+	boundingBox->faces[6].vertices[1]=0; \
+	boundingBox->faces[6].vertices[2]=5; \
+\
+	boundingBox->faces[7].triangle=1; \
+	boundingBox->faces[7].vertices[0]=0; \
+	boundingBox->faces[7].vertices[1]=1; \
+	boundingBox->faces[7].vertices[2]=5; \
+\
+	boundingBox->faces[8].triangle=1; \
+	boundingBox->faces[8].vertices[0]=7; \
+	boundingBox->faces[8].vertices[1]=3; \
+	boundingBox->faces[8].vertices[2]=0; \
+\
+	boundingBox->faces[9].triangle=1; \
+	boundingBox->faces[9].vertices[0]=0; \
+	boundingBox->faces[9].vertices[1]=4; \
+	boundingBox->faces[9].vertices[2]=7; \
+\
+	boundingBox->faces[10].triangle=1; \
+	boundingBox->faces[10].vertices[0]=6; \
+	boundingBox->faces[10].vertices[1]=5; \
+	boundingBox->faces[10].vertices[2]=1; \
+\
+	boundingBox->faces[11].triangle=1; \
+	boundingBox->faces[11].vertices[0]=1; \
+	boundingBox->faces[11].vertices[1]=2; \
+	boundingBox->faces[11].vertices[2]=6; 
 
 #define CONVERT_DEBUG_FACE_COORDINATES(src) \
 	vec3(src.v1[0]*IMARIO_SCALE, -src.v1[1]*IMARIO_SCALE, -src.v1[2]*IMARIO_SCALE), \
 	vec3(src.v2[0]*IMARIO_SCALE, -src.v2[1]*IMARIO_SCALE, -src.v2[2]*IMARIO_SCALE), \
 	vec3(src.v3[0]*IMARIO_SCALE, -src.v3[1]*IMARIO_SCALE, -src.v3[2]*IMARIO_SCALE)
 
-#define COUNT_ROOM_SECTORS(level, surfaces_count, room) \
-	COUNT_ROOM_SECTORS_UP(level, surfaces_count, room);\
-	COUNT_ROOM_SECTORS_DOWN(level, surfaces_count, room);
-
-#define ADD_ROOM_SECTORS(level, surfaces, surface_ind, room) \
-	ADD_ROOM_SECTORS_UP(level, surfaces, surface_ind, room);\
-	ADD_ROOM_SECTORS_DOWN(level, surfaces, surface_ind, room);
-
-void COUNT_ROOM_SECTORS_UP(TR::Level* level, size_t& surfaces_count, TR::Room& room)
-{
-	for (int i=0; i<room.xSectors * room.zSectors; i++)
-	{
-		if (room.sectors[i].roomAbove == TR::NO_ROOM) continue;
-		
-		TR::Room &roomUp = level->rooms[room.sectors[i].roomAbove];
-		TR::Room::Data &dUp = roomUp.data;
-		
-		for (int j = 0; j < dUp.fCount; j++)
-		{
-			TR::Face &f = dUp.faces[j];
-			if (f.water) continue;
-			
-			surfaces_count += (f.triangle) ? 1 : 2;
-		}
-		
-		COUNT_ROOM_SECTORS_UP(level, surfaces_count, roomUp);
-		break;
-	}
-}
-
-void COUNT_ROOM_SECTORS_DOWN(TR::Level* level, size_t& surfaces_count, TR::Room& room)
-{
-	for (int i=0; i<room.xSectors * room.zSectors; i++)
-	{
-		if (room.sectors[i].roomBelow == TR::NO_ROOM) continue;
-		
-		TR::Room &roomDown = level->rooms[room.sectors[i].roomBelow];
-		TR::Room::Data &dDown = roomDown.data;
-		
-		for (int j = 0; j < dDown.fCount; j++)
-		{
-			TR::Face &f = dDown.faces[j];
-			if (f.water) continue;
-			
-			surfaces_count += (f.triangle) ? 1 : 2;
-		}
-		
-		COUNT_ROOM_SECTORS_DOWN(level, surfaces_count, roomDown);
-		break;
-	}
-}
-
-void ADD_ROOM_SECTORS_UP(TR::Level* level, struct SM64Surface* surfaces, size_t& surface_ind, TR::Room& room)
-{
-	for (int i=0; i<room.xSectors * room.zSectors; i++)
-	{
-		if (room.sectors[i].roomAbove == TR::NO_ROOM) continue;
-		
-		TR::Room &roomUp = level->rooms[room.sectors[i].roomAbove];
-		TR::Room::Data &dUp = roomUp.data;
-		
-		for (int j = 0; j < dUp.fCount; j++)
-		{
-			TR::Face &f = dUp.faces[j];
-			if (f.water) continue;
-
-			ADD_FACE(surfaces, surface_ind, roomUp, dUp, f, false);
-		}
-		
-		ADD_ROOM_SECTORS_UP(level, surfaces, surface_ind, roomUp);
-		break;
-	}
-}
-
-void ADD_ROOM_SECTORS_DOWN(TR::Level* level, struct SM64Surface* surfaces, size_t& surface_ind, TR::Room& room)
-{
-	for (int i=0; i<room.xSectors * room.zSectors; i++)
-	{
-		if (room.sectors[i].roomBelow == TR::NO_ROOM) continue;
-		
-		TR::Room &roomDown = level->rooms[room.sectors[i].roomBelow];
-		TR::Room::Data &dDown = roomDown.data;
-		
-		for (int j = 0; j < dDown.fCount; j++)
-		{
-			TR::Face &f = dDown.faces[j];
-			if (f.water) continue;
-
-			ADD_FACE(surfaces, surface_ind, roomDown, dDown, f, false);
-		}
-		
-		ADD_ROOM_SECTORS_DOWN(level, surfaces, surface_ind, roomDown);
-		break;
-	}
-}
 
 #endif // H_MARIOMACROS

--- a/src/marioMacros.h
+++ b/src/marioMacros.h
@@ -40,35 +40,55 @@ extern "C" {
 		}}; \
 	}
 
-#define ADD_MESH_FACE_ABSOLUTE(surfaces, surface_ind, room, d, f) \
-	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, { \
-		{(room.info.x + d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
-		{(room.info.x + d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[1]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE}, \
-		{(room.info.x + d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
-	}}; \
-	if (!f.triangle) \
-	{ \
-		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, { \
-			{(room.info.x + d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
-			{(room.info.x + d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[3]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE}, \
-			{(room.info.x + d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
-		}}; \
-	}
 
-#define ADD_MESH_FACE_RELATIVE_SCALED(surfaces, surface_ind, d, f) \
-	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, { \
-		{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
-		{(d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[1]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE}, \
-		{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
-	}}; \
-	if (!f.triangle) \
-	{ \
-		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, { \
-			{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
-			{(d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[3]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE}, \
-			{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
-		}}; \
-	}
+#define X_GEOMETRY_TRANSFORMATION(x, displacement) (x+displacement)/IMARIO_SCALE
+#define Y_GEOMETRY_TRANSFORMATION(y) -y/IMARIO_SCALE
+#define Z_GEOMETRY_TRANSFORMATION(z, displacement) -(z+displacement)/IMARIO_SCALE
+
+
+#define ADD_CUBE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, maxx, miny, maxy, minz, maxz) \
+	ADD_CUBE_GEOMETRY_NON_TRANSFORMED( \
+		container, container_index, \
+		X_GEOMETRY_TRANSFORMATION(minx, xDisplacement), X_GEOMETRY_TRANSFORMATION(maxx, xDisplacement), \
+		Y_GEOMETRY_TRANSFORMATION(miny), Y_GEOMETRY_TRANSFORMATION(maxy), \
+		Z_GEOMETRY_TRANSFORMATION(minz, zDisplacement), Z_GEOMETRY_TRANSFORMATION(maxz, zDisplacement) \
+	)
+
+
+#define ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z) \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED( \
+		container, container_index, \
+		X_GEOMETRY_TRANSFORMATION(v0x, xDisplacement), Y_GEOMETRY_TRANSFORMATION(v0y), Z_GEOMETRY_TRANSFORMATION(v0z, zDisplacement), \
+		X_GEOMETRY_TRANSFORMATION(v1x, xDisplacement), Y_GEOMETRY_TRANSFORMATION(v1y), Z_GEOMETRY_TRANSFORMATION(v1z, zDisplacement), \
+		X_GEOMETRY_TRANSFORMATION(v2x, xDisplacement), Y_GEOMETRY_TRANSFORMATION(v2y), Z_GEOMETRY_TRANSFORMATION(v2z, zDisplacement) \
+	)
+
+
+#define ADD_CUBE_GEOMETRY_NON_TRANSFORMED(container, container_index, minx, maxx, miny, maxy, minz, maxz) \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, maxx, maxy, minz, minx, maxy, minz, minx, miny, minz) /*face1*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, minx, miny, minz, maxx, miny, minz, maxx, maxy, minz) /*face2*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, maxx, maxy, minz, maxx, miny, minz, maxx, miny, maxz) /*face3*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, maxx, miny, maxz, maxx, maxy, maxz, maxx, maxy, minz) /*face4*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, maxx, maxy, maxz, maxx, miny, maxz, minx, miny, maxz) /*face5*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, minx, miny, maxz, minx, maxy, maxz, maxx, maxy, maxz) /*face6*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, minx, miny, maxz, minx, miny, minz, minx, maxy, maxz) /*face7*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, minx, miny, minz, minx, maxy, minz, minx, maxy, maxz) /*face8*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, maxx, miny, maxz, maxx, miny, minz, minx, miny, minz) /*face9*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, minx, miny, minz, minx, miny, maxz, maxx, miny, maxz) /*face10*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, maxx, maxy, maxz, minx, maxy, maxz, minx, maxy, minz) /*face11*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, minx, maxy, minz, maxx, maxy, minz, maxx, maxy, maxz) /*face12*/
+
+#define ADD_RECTANGLE_HORIZONTAL_GEOMETRY_NON_TRANSFORMED(container, container_index, minx, maxx, minz, maxz) \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, minx, 0, maxz, minx, 0, minz, maxx, 0, maxz) \
+	ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, maxx, 0, minz, maxx, 0, maxz, minx, 0, minz)
+
+#define ADD_TRIANGLE_FACE_GEOMETRY_NON_TRANSFORMED(container, container_index, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z) \
+	container[container_index++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, { \
+		{ v2x , v2y, v2z }, \
+		{ v1x , v1y, v1z }, \
+		{ v0x , v0y, v0z } \
+	}};
+
 
 #define CREATE_BOUNDING_BOX(boundingBox, minx, maxx, miny, maxy, minz, maxz) \
 	boundingBox->vertices[0].coord.x=minx; \
@@ -163,27 +183,6 @@ extern "C" {
 	boundingBox->faces[11].vertices[1]=2; \
 	boundingBox->faces[11].vertices[2]=6; 
 
-#define ADD_CUBE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, maxx, miny, maxy, minz, maxz) \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, maxy, minz, minx, maxy, minz, minx, miny, minz) /*face1*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, miny, minz, maxx, miny, minz, maxx, maxy, minz) /*face2*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, maxy, minz, maxx, miny, minz, maxx, miny, maxz) /*face3*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, miny, maxz, maxx, maxy, maxz, maxx, maxy, minz) /*face4*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, maxy, maxz, maxx, miny, maxz, minx, miny, maxz) /*face5*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, miny, maxz, minx, maxy, maxz, maxx, maxy, maxz) /*face6*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, miny, maxz, minx, miny, minz, minx, maxy, maxz) /*face7*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, miny, minz, minx, maxy, minz, minx, maxy, maxz) /*face8*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, miny, maxz, maxx, miny, minz, minx, miny, minz) /*face9*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, miny, minz, minx, miny, maxz, maxx, miny, maxz) /*face10*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, maxy, maxz, minx, maxy, maxz, minx, maxy, minz) /*face11*/ \
-	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, maxy, minz, maxx, maxy, minz, maxx, maxy, maxz) /*face12*/
-
-
-#define ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z) \
-	container[container_index++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, { \
-		{( xDisplacement + v2x ) / IMARIO_SCALE, -v2y / IMARIO_SCALE, -( zDisplacement + v2z ) / IMARIO_SCALE}, \
-		{( xDisplacement + v1x ) / IMARIO_SCALE, -v1y / IMARIO_SCALE, -( zDisplacement + v1z ) / IMARIO_SCALE}, \
-		{( xDisplacement + v0x ) / IMARIO_SCALE, -v0y / IMARIO_SCALE, -( zDisplacement + v0z ) / IMARIO_SCALE}, \
-	}};
 
 #define CONVERT_DEBUG_FACE_COORDINATES(src) \
 	vec3(src.v1[0]*IMARIO_SCALE, -src.v1[1]*IMARIO_SCALE, -src.v1[2]*IMARIO_SCALE), \

--- a/src/marioMacros.h
+++ b/src/marioMacros.h
@@ -9,15 +9,15 @@ extern "C" {
 	#include <libsm64/src/decomp/include/surface_terrains.h>
 }
 
-#define ADD_ROOM_FACE_ABSOLUTE(surfaces, surface_ind, room, d, f, slippery, roomIndex, faceIndex) \
-	surfaces[surface_ind++] = {(int16_t)(slippery ? SURFACE_SLIPPERY : SURFACE_NOT_SLIPPERY), 0, TERRAIN_STONE, roomIndex, faceIndex, { \
+#define ADD_ROOM_FACE_ABSOLUTE(surfaces, surface_ind, room, d, f, slippery) \
+	surfaces[surface_ind++] = {(int16_t)(slippery ? SURFACE_SLIPPERY : SURFACE_NOT_SLIPPERY), 0, TERRAIN_STONE, { \
 		{(room.info.x + d->vertices[f.vertices[2]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[2]].pos.z)/IMARIO_SCALE}, \
 		{(room.info.x + d->vertices[f.vertices[1]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[1]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[1]].pos.z)/IMARIO_SCALE}, \
 		{(room.info.x + d->vertices[f.vertices[0]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[0]].pos.z)/IMARIO_SCALE}, \
 	}}; \
 	if (!f.triangle) \
 	{ \
-		surfaces[surface_ind++] = {(int16_t)(slippery ? SURFACE_SLIPPERY : SURFACE_NOT_SLIPPERY), 0, TERRAIN_STONE, roomIndex, faceIndex, { \
+		surfaces[surface_ind++] = {(int16_t)(slippery ? SURFACE_SLIPPERY : SURFACE_NOT_SLIPPERY), 0, TERRAIN_STONE, { \
 			{(room.info.x + d->vertices[f.vertices[0]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[0]].pos.z)/IMARIO_SCALE}, \
 			{(room.info.x + d->vertices[f.vertices[3]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[3]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[3]].pos.z)/IMARIO_SCALE}, \
 			{(room.info.x + d->vertices[f.vertices[2]].pos.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].pos.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[2]].pos.z)/IMARIO_SCALE}, \
@@ -26,14 +26,14 @@ extern "C" {
 
 
 #define ADD_MESH_FACE_RELATIVE(surfaces, surface_ind, d, f) \
-	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, -1, -1, { \
+	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, { \
 		{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
 		{(d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[1]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE}, \
 		{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
 	}}; \
 	if (!f.triangle) \
 	{ \
-		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, -1, -1, { \
+		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, { \
 			{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
 			{(d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[3]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE}, \
 			{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
@@ -41,14 +41,14 @@ extern "C" {
 	}
 
 #define ADD_MESH_FACE_ABSOLUTE(surfaces, surface_ind, room, d, f) \
-	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, -1, -1, { \
+	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, { \
 		{(room.info.x + d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
 		{(room.info.x + d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[1]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE}, \
 		{(room.info.x + d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
 	}}; \
 	if (!f.triangle) \
 	{ \
-		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, -1, -1, { \
+		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, { \
 			{(room.info.x + d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
 			{(room.info.x + d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[3]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE}, \
 			{(room.info.x + d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(room.info.z + d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
@@ -56,14 +56,14 @@ extern "C" {
 	}
 
 #define ADD_MESH_FACE_RELATIVE_SCALED(surfaces, surface_ind, d, f) \
-	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, -1, -1, { \
+	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, { \
 		{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
 		{(d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[1]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE}, \
 		{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
 	}}; \
 	if (!f.triangle) \
 	{ \
-		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, -1, -1, { \
+		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, { \
 			{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
 			{(d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[3]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE}, \
 			{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
@@ -102,66 +102,88 @@ extern "C" {
 	boundingBox->vertices[7].coord.x=maxx; \
 	boundingBox->vertices[7].coord.y=miny; \
 	boundingBox->vertices[7].coord.z=maxz; \
- \
+ /*face1*/\  
 	boundingBox->faces[0].triangle=1; \
-	boundingBox->faces[0].vertices[0]=2; \
+	boundingBox->faces[0].vertices[0]=2; \ 
 	boundingBox->faces[0].vertices[1]=1; \
 	boundingBox->faces[0].vertices[2]=0; \
- \
+ /*face2*/\
 	boundingBox->faces[1].triangle=1; \
 	boundingBox->faces[1].vertices[0]=0; \
 	boundingBox->faces[1].vertices[1]=3; \
 	boundingBox->faces[1].vertices[2]=2; \
-\
+/*face3*/\
 	boundingBox->faces[2].triangle=1; \
 	boundingBox->faces[2].vertices[0]=2; \
 	boundingBox->faces[2].vertices[1]=3; \
 	boundingBox->faces[2].vertices[2]=7; \
-\
+/*face4*/\
 	boundingBox->faces[3].triangle=1; \
 	boundingBox->faces[3].vertices[0]=7; \
 	boundingBox->faces[3].vertices[1]=6; \
 	boundingBox->faces[3].vertices[2]=2; \
-\
+/*face5*/\
 	boundingBox->faces[4].triangle=1; \
 	boundingBox->faces[4].vertices[0]=6; \
 	boundingBox->faces[4].vertices[1]=7; \
 	boundingBox->faces[4].vertices[2]=4; \
-\
+/*face6*/\
 	boundingBox->faces[5].triangle=1; \
 	boundingBox->faces[5].vertices[0]=4; \
 	boundingBox->faces[5].vertices[1]=5; \
 	boundingBox->faces[5].vertices[2]=6; \
-\
+/*face7*/\
 	boundingBox->faces[6].triangle=1; \
 	boundingBox->faces[6].vertices[0]=4; \
 	boundingBox->faces[6].vertices[1]=0; \
 	boundingBox->faces[6].vertices[2]=5; \
-\
+/*face8*/\
 	boundingBox->faces[7].triangle=1; \
 	boundingBox->faces[7].vertices[0]=0; \
 	boundingBox->faces[7].vertices[1]=1; \
 	boundingBox->faces[7].vertices[2]=5; \
-\
+/*face9*/\
 	boundingBox->faces[8].triangle=1; \
 	boundingBox->faces[8].vertices[0]=7; \
 	boundingBox->faces[8].vertices[1]=3; \
 	boundingBox->faces[8].vertices[2]=0; \
-\
+/*face10*/\
 	boundingBox->faces[9].triangle=1; \
 	boundingBox->faces[9].vertices[0]=0; \
 	boundingBox->faces[9].vertices[1]=4; \
 	boundingBox->faces[9].vertices[2]=7; \
-\
+/*face11*/\
 	boundingBox->faces[10].triangle=1; \
 	boundingBox->faces[10].vertices[0]=6; \
 	boundingBox->faces[10].vertices[1]=5; \
 	boundingBox->faces[10].vertices[2]=1; \
-\
+/*face12*/\
 	boundingBox->faces[11].triangle=1; \
 	boundingBox->faces[11].vertices[0]=1; \
 	boundingBox->faces[11].vertices[1]=2; \
 	boundingBox->faces[11].vertices[2]=6; 
+
+#define ADD_CUBE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, maxx, miny, maxy, minz, maxz) \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, maxy, minz, minx, maxy, minz, minx, miny, minz) /*face1*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, miny, minz, maxx, miny, minz, maxx, maxy, minz) /*face2*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, maxy, minz, maxx, miny, minz, maxx, miny, maxz) /*face3*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, miny, maxz, maxx, maxy, maxz, maxx, maxy, minz) /*face4*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, maxy, maxz, maxx, miny, maxz, minx, miny, maxz) /*face5*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, miny, maxz, minx, maxy, maxz, maxx, maxy, maxz) /*face6*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, miny, maxz, minx, miny, minz, minx, maxy, maxz) /*face7*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, miny, minz, minx, maxy, minz, minx, maxy, maxz) /*face8*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, miny, maxz, maxx, miny, minz, minx, miny, minz) /*face9*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, miny, minz, minx, miny, maxz, maxx, miny, maxz) /*face10*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, maxx, maxy, maxz, minx, maxy, maxz, minx, maxy, minz) /*face11*/ \
+	ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, minx, maxy, minz, maxx, maxy, minz, maxx, maxy, maxz) /*face12*/
+
+
+#define ADD_TRIANGLE_FACE_GEOMETRY(container, container_index, xDisplacement, zDisplacement, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z) \
+	container[container_index++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, { \
+		{( xDisplacement + v2x ) / IMARIO_SCALE, -v2y / IMARIO_SCALE, -( zDisplacement + v2z ) / IMARIO_SCALE}, \
+		{( xDisplacement + v1x ) / IMARIO_SCALE, -v1y / IMARIO_SCALE, -( zDisplacement + v1z ) / IMARIO_SCALE}, \
+		{( xDisplacement + v0x ) / IMARIO_SCALE, -v0y / IMARIO_SCALE, -( zDisplacement + v0z ) / IMARIO_SCALE}, \
+	}};
 
 #define CONVERT_DEBUG_FACE_COORDINATES(src) \
 	vec3(src.v1[0]*IMARIO_SCALE, -src.v1[1]*IMARIO_SCALE, -src.v1[2]*IMARIO_SCALE), \

--- a/src/marioMacros.h
+++ b/src/marioMacros.h
@@ -55,6 +55,21 @@ extern "C" {
 		}}; \
 	}
 
+#define ADD_MESH_FACE_RELATIVE_SCALED(surfaces, surface_ind, d, f) \
+	surfaces[surface_ind++] = {(int16_t)(SURFACE_DEFAULT), 0, TERRAIN_STONE, -1, -1, { \
+		{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
+		{(d->vertices[f.vertices[1]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[1]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[1]].coord.z)/IMARIO_SCALE}, \
+		{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
+	}}; \
+	if (!f.triangle) \
+	{ \
+		surfaces[surface_ind++] = {(int16_t)((int16_t)(SURFACE_DEFAULT)), 0, TERRAIN_STONE, -1, -1, { \
+			{(d->vertices[f.vertices[0]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[0]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[0]].coord.z)/IMARIO_SCALE}, \
+			{(d->vertices[f.vertices[3]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[3]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[3]].coord.z)/IMARIO_SCALE}, \
+			{(d->vertices[f.vertices[2]].coord.x)/IMARIO_SCALE, -d->vertices[f.vertices[2]].coord.y/IMARIO_SCALE, -(d->vertices[f.vertices[2]].coord.z)/IMARIO_SCALE}, \
+		}}; \
+	}
+
 #define CREATE_BOUNDING_BOX(boundingBox, minx, maxx, miny, maxy, minz, maxz) \
 	boundingBox->vertices[0].coord.x=minx; \
 	boundingBox->vertices[0].coord.y=miny; \
@@ -153,5 +168,14 @@ extern "C" {
 	vec3(src.v2[0]*IMARIO_SCALE, -src.v2[1]*IMARIO_SCALE, -src.v2[2]*IMARIO_SCALE), \
 	vec3(src.v3[0]*IMARIO_SCALE, -src.v3[1]*IMARIO_SCALE, -src.v3[2]*IMARIO_SCALE)
 
+
+#define TEST_FACE_OVERLAP(face1, face2, mainAxis, otherAxis) \
+	face1.positive != face2.positive && face1.mainAxis[0] == face2.mainAxis[0] && \
+	!(\
+		((face1.otherAxis[0] == face2.otherAxis[0] && face1.otherAxis[1] == face2.otherAxis[1]) ? \
+			face1.y[0] > face2.y[1] || face1.y[1] < face2.y[0] : \
+			face1.y[0] >= face2.y[1] || face1.y[1] <= face2.y[0] ) \
+		|| face1.otherAxis[0] >= face2.otherAxis[1] || face1.otherAxis[1] <= face2.otherAxis[0] \
+	)\
 
 #endif // H_MARIOMACROS

--- a/src/marioMacros.h
+++ b/src/marioMacros.h
@@ -124,7 +124,7 @@ extern "C" {
 	boundingBox->vertices[7].coord.z=maxz; \
  /*face1*/\  
 	boundingBox->faces[0].triangle=1; \
-	boundingBox->faces[0].vertices[0]=2; \ 
+	boundingBox->faces[0].vertices[0]=2; \
 	boundingBox->faces[0].vertices[1]=1; \
 	boundingBox->faces[0].vertices[2]=0; \
  /*face2*/\


### PR DESCRIPTION
Implemented clipper boxs to avoid the player to clip through 1 face thin walls. Those are calculated everytime a player changes rooms and only over the loaded rooms for that player. Since rooms flip with other rooms we can't just pre-calculate these boxes.

Created a better structure to implement how we deal with static mesh loading overrides.

Added macros to create boxes triangles and squares.

Extracted map management related stuff from mario.h into levelsm64.h. This struct will be available on every entity that inherits controller as levelSM64 (much like level is). This gives a lot of advantages: 

- This is loaded and unloaded with open lara level which is more seamless instead of being tied to the player spawn.
- Since the map is prepared sooner then it will keep track of map flips if started as lara. 
- Makes sense to have map management related logic separated from player logic.

Mario can only be instantiated in the first update tick since entities constructor is called prior the map being fully loaded. levelSM64 has a function to facilitate the correct loading process that can be shared between the player and doppelganger.

Added some fix to room loading and static meshes for palace midas level.
Added some fixes to static meshes for City of Vilcabamba.