### PR TITLE
Improved trap floor behavior and optimized Clip faces detection

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -17,13 +17,42 @@
                 "DGEOMETRY_EXPORT",
                 "WIN32",
                 "_WIN32",
-                "GEOMETRY_EXPORT"
+                "GEOMETRY_EXPORT",
+                "DECODE_VAG"
             ],
             "compilerPath": "C:\\msys64\\mingw64\\bin\\g++.exe",
             "cStandard": "c17",
-            "cppStandard": "c++20",
-            "intelliSenseMode": "clang-x64",
-            "configurationProvider": "ms-vscode.makefile-tools"
+            "cppStandard": "c++11",
+            "intelliSenseMode": "clang-x86",
+            "compilerArgs": [
+                "-std=c++11",
+                "-g",
+                "-fno-exceptions",
+                "-fno-rtti",
+                "-ffunction-sections",
+                "-fdata-sections",
+                "-Wl,--gc-sections",
+                "-DWIN32",
+                "-DNDEBUG",
+                "-DDEBUG_RENDER",
+                "-DNO_TOUCH_SUPPORT",
+                "-DGEOMETRY_EXPORT",
+                "-I../../libs/",
+                "main.cpp",
+                "../../libs/stb_vorbis/stb_vorbis.c",
+                "../../libs/minimp3/minimp3.cpp",
+                "../../libs/tinf/tinflate.c",
+                "OpenLara.rc.o",
+                "-I../../",
+                "-o../../../bin/OpenLara_mingw.exe",
+                "-L../../libs/libsm64/dist",
+                "-lsm64",
+                "-lopengl32",
+                "-lwinmm",
+                "-lwsock32",
+                "-lgdi32",
+                "-lm"
+            ]
         }
     ],
     "version": 4

--- a/src/debug.h
+++ b/src/debug.h
@@ -16,6 +16,7 @@ extern "C" {
 #include "controller.h"
 #include "mesh.h"
 #include "marioMacros.h"
+#include "enemy.h"
 
 namespace Debug {
 
@@ -673,56 +674,54 @@ namespace Debug {
             Core::setDepthTest(true);            
         }
 
-        void sm64debugrooms(TR::Level *level, int *roomslist, int roomscount) {
+        void sm64debugrooms(TR::Level *level, int roomIndex) 
+        {
+            TR::Room &room = level->rooms[roomIndex];
+            TR::Room::Data &d = room.data;
 
-            for(int roomIndex=0; roomIndex<roomscount; roomIndex++)
+            Core::setDepthTest(false); 
+            for (int j = 0; j < d.fCount; j++)
             {
-                TR::Room &room = level->rooms[roomslist[roomIndex]];
-                TR::Room::Data &d = room.data;
-
-                Core::setDepthTest(false); 
-                for (int j = 0; j < d.fCount; j++)
+                TR::Face &f = d.faces[j];
+                if (!f.triangle)
                 {
-                    TR::Face &f = d.faces[j];
-                    if (!f.triangle)
-                    {
-                        Debug::Draw::staticface(
-                            vec3((float)d.vertices[f.vertices[0]].pos.x+room.info.x, (float)d.vertices[f.vertices[0]].pos.y, (float)d.vertices[f.vertices[0]].pos.z+room.info.z),
-                            vec3((float)d.vertices[f.vertices[1]].pos.x+room.info.x, (float)d.vertices[f.vertices[1]].pos.y, (float)d.vertices[f.vertices[1]].pos.z+room.info.z),
-                            vec3((float)d.vertices[f.vertices[2]].pos.x+room.info.x, (float)d.vertices[f.vertices[2]].pos.y, (float)d.vertices[f.vertices[2]].pos.z+room.info.z),
-                            vec3((float)d.vertices[f.vertices[3]].pos.x+room.info.x, (float)d.vertices[f.vertices[3]].pos.y, (float)d.vertices[f.vertices[3]].pos.z+room.info.z),
-                            vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
+                    Debug::Draw::staticface(
+                        vec3((float)d.vertices[f.vertices[0]].pos.x+room.info.x, (float)d.vertices[f.vertices[0]].pos.y, (float)d.vertices[f.vertices[0]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[1]].pos.x+room.info.x, (float)d.vertices[f.vertices[1]].pos.y, (float)d.vertices[f.vertices[1]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[2]].pos.x+room.info.x, (float)d.vertices[f.vertices[2]].pos.y, (float)d.vertices[f.vertices[2]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[3]].pos.x+room.info.x, (float)d.vertices[f.vertices[3]].pos.y, (float)d.vertices[f.vertices[3]].pos.z+room.info.z),
+                        vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
 
-                        
-                        char buf[255];
-                        sprintf(buf, "Room: %d Id: %d", roomslist[roomIndex], j);
-                        Debug::Draw::text(
-                            vec3(
-                                (d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+d.vertices[f.vertices[3]].pos.x+(4*room.info.x))/4.0f,
-                                (d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y+d.vertices[f.vertices[3]].pos.y)/4.0f,
-                                (d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+d.vertices[f.vertices[3]].pos.z+(4*room.info.z))/4.0f
-                                ), vec4(0.5, 0.5, 1.0, 1), buf);
-                    }
-                    else
-                    {
-                        Debug::Draw::triangle(
-                            vec3((float)d.vertices[f.vertices[0]].pos.x+room.info.x, (float)d.vertices[f.vertices[0]].pos.y, (float)d.vertices[f.vertices[0]].pos.z+room.info.z),
-                            vec3((float)d.vertices[f.vertices[1]].pos.x+room.info.x, (float)d.vertices[f.vertices[1]].pos.y, (float)d.vertices[f.vertices[1]].pos.z+room.info.z),
-                            vec3((float)d.vertices[f.vertices[2]].pos.x+room.info.x, (float)d.vertices[f.vertices[2]].pos.y, (float)d.vertices[f.vertices[2]].pos.z+room.info.z),
-                            vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
-
-                        
-                        char buf[255];
-                        sprintf(buf, "Room: %d Id: %d", roomslist[roomIndex], j);
-                        Debug::Draw::text(
-                            vec3(
-                                (d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+(3*room.info.x))/3.0f,
-                                (d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y)/3.0f + (roomslist[roomIndex]==50 ? 20 : 0),
-                                (d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+(3*room.info.z))/3.0f
-                                ), vec4(0.5, 0.5, 1.0, 1), buf);
-                    }                    
+                    
+                    char buf[255];
+                    sprintf(buf, "Room: %d Id: %d", roomIndex, j);
+                    Debug::Draw::text(
+                        vec3(
+                            (d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+d.vertices[f.vertices[3]].pos.x+(4*room.info.x))/4.0f,
+                            (d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y+d.vertices[f.vertices[3]].pos.y)/4.0f,
+                            (d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+d.vertices[f.vertices[3]].pos.z+(4*room.info.z))/4.0f
+                            ), vec4(0.5, 0.5, 1.0, 1), buf);
                 }
+                else
+                {
+                    Debug::Draw::triangle(
+                        vec3((float)d.vertices[f.vertices[0]].pos.x+room.info.x, (float)d.vertices[f.vertices[0]].pos.y, (float)d.vertices[f.vertices[0]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[1]].pos.x+room.info.x, (float)d.vertices[f.vertices[1]].pos.y, (float)d.vertices[f.vertices[1]].pos.z+room.info.z),
+                        vec3((float)d.vertices[f.vertices[2]].pos.x+room.info.x, (float)d.vertices[f.vertices[2]].pos.y, (float)d.vertices[f.vertices[2]].pos.z+room.info.z),
+                        vec4(0.3f, 0.2f, 0.5f, 0.5f), vec4(1.0f, 1.0f, 1.0f, 0.1f));
+
+                    
+                    char buf[255];
+                    sprintf(buf, "Room: %d Id: %d", roomIndex, j);
+                    Debug::Draw::text(
+                        vec3(
+                            (d.vertices[f.vertices[0]].pos.x+d.vertices[f.vertices[1]].pos.x+d.vertices[f.vertices[2]].pos.x+(3*room.info.x))/3.0f,
+                            (d.vertices[f.vertices[0]].pos.y+d.vertices[f.vertices[1]].pos.y+d.vertices[f.vertices[2]].pos.y)/3.0f,
+                            (d.vertices[f.vertices[0]].pos.z+d.vertices[f.vertices[1]].pos.z+d.vertices[f.vertices[2]].pos.z+(3*room.info.z))/3.0f
+                            ), vec4(0.5, 0.5, 1.0, 1), buf);
+                }                    
             }
+            
             Core::setDepthTest(true);                        
         }
 
@@ -911,7 +910,7 @@ namespace Debug {
             }
         }
 
-        void info(IGame *game, Controller *controller, Animation &anim) {
+        void info(IGame *game, Controller *controller, Animation &anim, LevelSM64 *levelSM64) {
             TR::Level &level = *game->getLevel();
 
             if (level.isCutsceneLevel()) return;
@@ -947,6 +946,17 @@ namespace Debug {
                 (saveStats.secrets & 2) ? '1' : '0',
                 (saveStats.secrets & 1) ? '1' : '0', saveStats.pickups, saveStats.mediUsed, saveStats.ammoUsed, saveStats.kills);
             Debug::Draw::text(vec2(16, y += 16), vec4(1.0f), buf);
+
+            if(levelSM64)
+            {
+                int index = 0;
+                index = sprintf(buf, "SM64: clipBoxes = %d, clipTime: %.2fms, roomsLoaded:", levelSM64->clipsCount, levelSM64->clipsTimeTaken);
+                for (int i=0; i<levelSM64->loadedRoomsCount; i++)
+                {
+                    index += sprintf(&buf[index], " %d", levelSM64->loadedRooms[i]);
+                }
+                Debug::Draw::text(vec2(16, y += 16), vec4(1.0f), buf);
+            }
 
             y += 16;
             if (info.lava)

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -2555,10 +2555,7 @@ struct MarioDoppelganger: Enemy
 
         if(marioId!=-1)
         {
-            int nearRooms[256];
-            int nearRoomsCount=0;
-            levelSM64->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, getRoomIndex(), getRoomIndex(), 1);
-            sm64_level_update_loaded_rooms_list(marioId, nearRooms, nearRoomsCount);
+            levelSM64->getCurrentAndAdjacentRoomsWithClips(marioId, getRoomIndex(), getRoomIndex(), 1);
         }
 
 		if (stand != STAND_AIR && tickedOnce)

--- a/src/lara.h
+++ b/src/lara.h
@@ -2275,7 +2275,7 @@ struct Lara : Character {
 			int roomsSwitchedCount=0;
             game->flipMap(roomsSwitched, roomsSwitchedCount);
             game->setEffect(this, effect);
-            sm64_level_rooms_switch(roomsSwitched, roomsSwitchedCount);
+            levelSM64->flipMap(roomsSwitched, roomsSwitchedCount);
         }
     }
 

--- a/src/level.h
+++ b/src/level.h
@@ -2452,6 +2452,14 @@ struct Level : IGame {
             surfaceDebugger=!surfaceDebugger;
             Input::down[ikF4] = false;
         }
+        if (Input::down[ikF5]) {
+            Lara *lara = (Lara *)getLara(0);
+            if(lara!=NULL && lara->isMario)
+            {
+                lara->setDozy(true);
+            }
+            Input::down[ikF5] = false;
+        }
     #endif
     }
 
@@ -3173,11 +3181,8 @@ struct Level : IGame {
             {
                 Lara *lara = (Lara *)getLara(0);
 
-                if(lara && levelSM64){
-                    int nearRooms[256];
-                    int nearRoomsCount=0;
-                    levelSM64->getCurrentAndAdjacentRooms(nearRooms, &nearRoomsCount, lara->getRoomIndex(), lara->getRoomIndex(), 0);
-                    Debug::Level::sm64debugrooms(&level, nearRooms, nearRoomsCount);
+                if(lara){
+                    Debug::Level::sm64debugrooms(&level, lara->getRoomIndex());
                 }
             }
             
@@ -3266,7 +3271,7 @@ struct Level : IGame {
             glLineWidth(1);           
         */
 
-            Debug::Level::info(this, player, player->animation);
+            Debug::Level::info(this, player, player->animation, levelSM64);
 
 
         Debug::end();

--- a/src/level.h
+++ b/src/level.h
@@ -277,7 +277,7 @@ struct Level : IGame {
                 int roomsSwitched[level.roomsCount][2];
                 int roomsSwitchedCount=0;
                 flipMap(roomsSwitched, roomsSwitchedCount);
-                sm64_level_rooms_switch(roomsSwitched, roomsSwitchedCount);
+                levelSM64->flipMap(roomsSwitched, roomsSwitchedCount);
                 level.state.flags.flipped = true;
             }
 

--- a/src/mario.h
+++ b/src/mario.h
@@ -826,7 +826,7 @@ struct Mario : Lara
 			int roomsSwitchedCount=0;
 			game->flipMap(roomsSwitched, roomsSwitchedCount);
 			game->setEffect(this, effect);
-			sm64_level_rooms_switch(roomsSwitched, roomsSwitchedCount);
+			levelSM64->flipMap(roomsSwitched, roomsSwitchedCount);
 		}
 	}
 

--- a/src/marioMacros.h
+++ b/src/marioMacros.h
@@ -191,12 +191,12 @@ extern "C" {
 
 
 #define TEST_FACE_OVERLAP(face1, face2, mainAxis, otherAxis) \
-	face1.positive != face2.positive && face1.mainAxis[0] == face2.mainAxis[0] && \
+	face1->positive != face2->positive && face1->mainAxis[0] == face2->mainAxis[0] && \
 	!(\
-		((face1.otherAxis[0] == face2.otherAxis[0] && face1.otherAxis[1] == face2.otherAxis[1]) ? \
-			face1.y[0] > face2.y[1] || face1.y[1] < face2.y[0] : \
-			face1.y[0] >= face2.y[1] || face1.y[1] <= face2.y[0] ) \
-		|| face1.otherAxis[0] >= face2.otherAxis[1] || face1.otherAxis[1] <= face2.otherAxis[0] \
+		((face1->otherAxis[0] == face2->otherAxis[0] && face1->otherAxis[1] == face2->otherAxis[1]) ? \
+			face1->limits[0][0] > face2->limits[0][1] || face1->limits[0][1] < face2->limits[0][0] : \
+			face1->limits[0][0] >= face2->limits[0][1] || face1->limits[0][1] <= face2->limits[0][0] ) \
+		|| face1->otherAxis[0] >= face2->otherAxis[1] || face1->otherAxis[1] <= face2->otherAxis[0] \
 	)\
 
 #endif // H_MARIOMACROS


### PR DESCRIPTION
Updated libsm64 to avoid null memory usage when falling into a trap floor.

Trap floors are now a box instead of a single plane. This avoids mario from clipping through it when jumping from bellow.

Added debug text to the top left of the screen in debug mode with the number of clips found, how long it took to calculate clips and current loaded rooms.

Added precache of all rooms and faces limits at the initial level loading to improve performance for the clip faces search. The search will also now discard comparisons with faces from rooms that aren't near the current room since those will never be necessary.

The function getCurrentAndAdjacentRoomsWithClips will now be centralized on levelSM64 since it makes all the required setup.

FlipMap now passes through levelSM64 to update the cached rooms config


