### PR TITLE
Discards rooms far away from mario and dynamic objects update no centralized on levelSM64

### DIFF
--- a/src/controller.h
+++ b/src/controller.h
@@ -5,6 +5,7 @@
 #include "frustum.h"
 #include "mesh.h"
 #include "animation.h"
+#include "marioMacros.h"
 
 #define GRAVITY     6.0f
 #define SPRITE_FPS  10.0f
@@ -28,6 +29,21 @@ namespace SM64
         bool spawned;
     };
 
+    struct MarioPlayer
+    {
+        int marioId=-1;
+        int lastClipsFound = 0;
+
+        double clipsTimeTaken = 0.0;
+        double marioTickTimeTaken=0.0;
+
+        int loadedRooms[256];
+	    int loadedRoomsCount = 0;
+
+        int discardedRooms[256];
+	    int discardedRoomsCount = 0;
+    };
+
     struct ILevelSM64 
     {
         ILevelSM64(){}
@@ -39,20 +55,22 @@ namespace SM64
             MESH_LOADING_BOUNDING_BOX
 	    };
 
-        int lastClipsFound = 0;
-	    double clipsTimeTaken = 0.0;
+        struct MarioPlayer marioPlayers[MAX_MARIO_PLAYERS];
 
-        int loadedRooms[256];
-	    int loadedRoomsCount=0;
+        double updateDynamicTimeTaken=0.0;
+        double loadLevelTimeTaken=0.0;
 
         struct MarioControllerObj dynamicObjects[4096];
 	    int dynamicObjectsCount=0;
 
         virtual void loadSM64Level(TR::Level *newLevel, void *player, int initRoom=0){}
-        virtual void getCurrentAndAdjacentRoomsWithClips(int marioId, int currentRoomIndex, int to, int maxDepth, bool evaluateClips = false){}
-        virtual int createMarioInstance(int roomIndex, vec3(pos)){return 0;}
+        virtual void getCurrentAndAdjacentRoomsWithClips(int marioId, vec3 position, int currentRoomIndex, int to, int maxDepth, bool evaluateClips = false){}
+        virtual int createMarioInstance(int roomIndex, vec3 pos){return 0;}
         virtual void flipMap(int rooms[][2], int count){}
         virtual void updateTransformation(TR::Entity *entity, struct SM64ObjectTransform *transform){}
+        virtual void updateDynamicObjects(){}
+        virtual void marioTick(int32_t marioId, const struct SM64MarioInputs *inputs, struct SM64MarioState *outState, struct SM64MarioGeometryBuffers *outBuffers){}
+        virtual void deleteMarioInstance(int marioId) {}
     };
 }
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -607,7 +607,7 @@ namespace Debug {
             }
         }
 
-        void sm64debug(Lara *lara, TR::Level *level) {
+        void sm64debug(Lara *lara, TR::Level *level, SM64::ILevelSM64 *levelSM64) {
 
             if(!lara->surfaceDebuggerEnabled || !lara->isMario || !level)
             {
@@ -654,11 +654,6 @@ namespace Debug {
                     TR::Room::Mesh &m  = r.meshes[j];
                     TR::StaticMesh *sm = &level->staticMeshes[m.meshIndex];
 
-                    // if (sm->flags != 2 || !level->meshOffsets[sm->mesh])
-                    // {
-                    //     continue;
-                    // }
-
                     Box box;
                     vec3 offset = vec3(float(m.x), float(m.y), float(m.z));
                     sm->getBox(false, m.rotation, box); // visible box
@@ -668,8 +663,6 @@ namespace Debug {
                         sprintf(buf, "ID: %d", (int)m.meshIndex);
                         Debug::Draw::text(offset + (box.min + box.max) * 0.5f, vec4(0.5, 0.5, 1.0, 1), buf);
                     }
-                    
-                    
                 }
             }
             
@@ -1018,13 +1011,32 @@ namespace Debug {
 
             if(levelSM64)
             {
-                int index = 0;
-                index = sprintf(buf, "SM64: clipBoxes = %d, clipTime: %.2fms, roomsLoaded:", levelSM64->lastClipsFound, levelSM64->clipsTimeTaken);
-                for (int i=0; i<levelSM64->loadedRoomsCount; i++)
-                {
-                    index += sprintf(&buf[index], " %d", levelSM64->loadedRooms[i]);
-                }
+                sprintf(buf, "SM64: RoomsLoaded = %d, LevelLoadTime: %.2fms, dynamicObjects: %d, dynamicObjectsUpdateTime: %.3fms", 
+                    level.roomsCount, levelSM64->loadLevelTimeTaken, levelSM64->dynamicObjectsCount, levelSM64->updateDynamicTimeTaken);
                 Debug::Draw::text(vec2(16, y += 16), vec4(1.0f), buf);
+
+                for(int i=0; i<MAX_MARIO_PLAYERS; i++)
+                {
+                    SM64::MarioPlayer *player = &(levelSM64->marioPlayers[i]);
+                    if(player->marioId!=-1)
+                    {
+                        int index = sprintf(buf, "Mario Id: %d, tickTime: %.4fms, clipBoxes = %d, clipTime: %.4fms, roomsLoaded:", 
+                            player->marioId, player->marioTickTimeTaken, player->lastClipsFound, player->clipsTimeTaken);
+
+                        for (int j=0; j<player->loadedRoomsCount; j++)
+                        {
+                            index += sprintf(&buf[index], " %d", player->loadedRooms[j]);
+                        }
+
+                        index += sprintf(&buf[index], " discardedRooms:");
+                        for (int j=0; j<player->discardedRoomsCount; j++)
+                        {
+                            index += sprintf(&buf[index], " %d", player->discardedRooms[j]);
+                        }
+
+                        Debug::Draw::text(vec2(16, y += 16), vec4(1.0f), buf);
+                    }                    
+                }
             }
 
             y += 16;

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -2512,7 +2512,7 @@ struct MarioDoppelganger: Enemy
 		delete TRmarioMesh;
 		delete marioDoppelgangerTex;
 
-		if (marioId != -1) sm64_mario_delete(marioId);
+		if (marioId != -1) levelSM64->deleteMarioInstance(marioId);
 	}
 
 	void render(Frustum *frustum, MeshBuilder *mesh, Shader::Type type, bool caustics)
@@ -2555,7 +2555,7 @@ struct MarioDoppelganger: Enemy
 
         if(marioId!=-1)
         {
-            levelSM64->getCurrentAndAdjacentRoomsWithClips(marioId, getRoomIndex(), getRoomIndex(), 1);
+            levelSM64->getCurrentAndAdjacentRoomsWithClips(marioId, pos, getRoomIndex(), getRoomIndex(), 1);
         }
 
 		if (stand != STAND_AIR && tickedOnce)

--- a/src/level.h
+++ b/src/level.h
@@ -1130,8 +1130,6 @@ struct Level : IGame {
 
     virtual ~Level() {
         UI::init(NULL);
-        if(levelSM64!=NULL)
-            delete levelSM64;
         Network::stop();
 
         for (int i = 0; i < level.entitiesCount; i++)
@@ -1151,6 +1149,9 @@ struct Level : IGame {
             delete atlasGlyphs;
         #endif
         delete mesh;
+
+        if(levelSM64!=NULL)
+            delete levelSM64;
 
         Sound::stopAll();
     }
@@ -2369,6 +2370,7 @@ struct Level : IGame {
                     c->update();
                     c = next;
                 }
+                levelSM64->updateDynamicObjects();
             } else {
                 if (camera->spectator) {
                     camera->update();

--- a/src/marioMacros.h
+++ b/src/marioMacros.h
@@ -3,6 +3,7 @@
 
 #define MARIO_SCALE 4.f
 #define IMARIO_SCALE 4
+#define MAX_MARIO_PLAYERS 10
 
 extern "C" {
 	#include <libsm64/src/libsm64.h>
@@ -202,5 +203,29 @@ extern "C" {
 			face1->limits[0][0] >= face2->limits[0][1] || face1->limits[0][1] <= face2->limits[0][0] ) \
 		|| face1->otherAxis[0] >= face2->otherAxis[1] || face1->otherAxis[1] <= face2->otherAxis[0] \
 	)\
+
+#ifdef DEBUG_RENDER
+#define DEBUG_TIME_INIT() \
+struct timespec start, stop; \
+clock_gettime( CLOCK_REALTIME, &start);
+#else
+#define DEBUG_TIME_INIT() do { } while(0)
+#endif
+
+#ifdef DEBUG_RENDER
+#define DEBUG_TIME_END(target) \
+clock_gettime( CLOCK_REALTIME, &stop); \
+target = (( stop.tv_sec - start.tv_sec ) + ( stop.tv_nsec - start.tv_nsec )/1E9L)*1E3L;
+#else
+#define DEBUG_TIME_END(target) do { } while(0)
+#endif
+
+#ifdef DEBUG_RENDER
+#define DEBUG_TIME_END_AVERAGED(target) \
+clock_gettime( CLOCK_REALTIME, &stop); \
+target = (target*(59.0/60.0))+((( stop.tv_sec - start.tv_sec ) + ( stop.tv_nsec - start.tv_nsec )/1E9L)*1E3L*1.0/60.0);
+#else
+#define DEBUG_TIME_END(target) do { } while(0)
+#endif
 
 #endif // H_MARIOMACROS


### PR DESCRIPTION
- Moved the dynamic objects update out of mario.h into levelSM64 and it's now called at the end of each level update cycle in level.h. This avoids updating the information twice when there were 2 Mario players.
- Centralized the mario instance creation and deletion on levelSM64. This allows to keep track of each mario stats independently. 
- Added more information to the debugger.
- Now the big one: after traversing and selecting the rooms to load It evaluates if Mario is even near those rooms (at least 2cell distance which is 2048). If he isn't then It discards the room from the loaded rooms. This makes a huge performance improvement.