### PR TITLE
Fixed crash when loading with pickups active.

### DIFF
--- a/src/ui.h
+++ b/src/ui.h
@@ -540,11 +540,12 @@ namespace UI {
     #undef MAX_CHARS
 
     void init(IGame *game) {
-        ensureLanguage(Core::settings.audio.language);
-        UI::game = game;
-        showHelp = false;
-        helpTipTime = 5.0f;
-        hintTime = subsTime = 0.0f;
+		ensureLanguage(Core::settings.audio.language);
+		UI::game = game;
+		showHelp = false;
+		helpTipTime = 5.0f;
+		hintTime = subsTime = 0.0f;
+		pickups.clear();
     }
 
     void deinit() {


### PR DESCRIPTION
This would happen when you had a pickup actively rotating in the corner of the screen and loaded a save or transitioned to a new level.