### PR TITLE
Dynamic objects now manage multiple joints.

### DIFF
--- a/src/controller.h
+++ b/src/controller.h
@@ -21,17 +21,6 @@ struct Controller;
 
 namespace SM64
 {
-    struct MarioControllerObj
-    {
-        MarioControllerObj() : ID(0), entity(NULL), spawned(false) {}
-
-        uint32_t ID;
-        struct SM64ObjectTransform transform;
-        TR::Entity* entity;
-        vec3 offset;
-        bool spawned;
-    };
-
     struct CrossedPortal
     {
         int from;
@@ -77,9 +66,6 @@ namespace SM64
 
         double updateDynamicTimeTaken=0.0;
         double loadLevelTimeTaken=0.0;
-
-        struct MarioControllerObj dynamicObjects[4096];
-	    int dynamicObjectsCount=0;
 
         virtual void loadSM64Level(TR::Level *newLevel, void *player, int initRoom=0){}
         virtual void getCurrentAndAdjacentRoomsWithClips(int marioId, vec3 position, int currentRoomIndex, int to, int maxDepth, bool evaluateClips = false){}

--- a/src/debug.h
+++ b/src/debug.h
@@ -1061,8 +1061,8 @@ namespace Debug {
 
             if(levelSM64)
             {
-                sprintf(buf, "SM64: RoomsLoaded = %d, LevelLoadTime: %.2fms, dynamicObjects: %d, dynamicObjectsUpdateTime: %.3fms", 
-                    level.roomsCount, levelSM64->loadLevelTimeTaken, levelSM64->dynamicObjectsCount, levelSM64->updateDynamicTimeTaken);
+                sprintf(buf, "SM64: RoomsLoaded = %d, LevelLoadTime: %.2fms, dynamicObjectsUpdateTime: %.3fms", 
+                    level.roomsCount, levelSM64->loadLevelTimeTaken, levelSM64->updateDynamicTimeTaken);
                 Debug::Draw::text(vec2(16, y += 16), vec4(1.0f), buf);
 
                 for(int i=0; i<MAX_MARIO_PLAYERS; i++)


### PR DESCRIPTION
Each joint will have it's own geometry and transformations. 

Every single dynamic object management is centralized in the MarioControllerObj. 

Added support for bounding box replacement or even specific joints replacements. 

Fixed cabin in natla's mines. 

Static meshes when using bounding boxes now have a minimum delta in each axis to avoid too thin static meshes that mario can clip through or get stuck.